### PR TITLE
Build C libraries from SHA256-pinned tarballs

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -14,3 +14,7 @@ ignored:
   # SC2035: Use ./*glob* or -- *glob* so names with dashes won't become options
   # The sha256sum command is safe with our controlled filenames
   - SC2035
+
+  # DL3022: COPY --from should reference a previously defined FROM alias
+  # The `deps` context is an additional build context (--build-context), not a stage
+  - DL3022

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,16 @@ tag-release: ## Tag the current commit with the release version
 .PHONY: all
 all: build
 
+# Shared static library prefix (openssl, zlib, nghttp2, ...)
+.PHONY: deps
+deps:
+	@echo "==> Building static prefix for $(HOST_ARCH)"
+	$(MAKE) -C deps build ARCH=$(HOST_ARCH) OUT_DIR=$(OUT_DIR)
+
+.PHONY: deps-all
+deps-all:
+	$(MAKE) -C deps build-all OUT_DIR=$(OUT_DIR)
+
 # Build all tools for host architecture (local development)
 .PHONY: build
 build: $(addprefix build-,$(TOOLS))
@@ -94,6 +104,7 @@ lint:
 		chmod +x /tmp/hadolint; \
 		HADOLINT=/tmp/hadolint; \
 	fi; \
+	$$HADOLINT --config .hadolint.yaml deps/Dockerfile || exit 1; \
 	for tool in $(TOOLS); do \
 		$$HADOLINT --config .hadolint.yaml tools/$$tool/Dockerfile || exit 1; \
 	done
@@ -118,6 +129,7 @@ gittuf-verify:
 .PHONY: clean
 clean:
 	rm -rf $(OUT_DIR)
+	$(MAKE) -C deps clean OUT_DIR=$(OUT_DIR);
 	$(foreach tool,$(TOOLS),$(MAKE) -C tools/$(tool) clean;)
 
 # List available tools
@@ -132,6 +144,7 @@ help:
 	@echo "static-tools - Statically compiled binaries with SLSA provenance"
 	@echo ""
 	@echo "Usage:"
+	@echo "  make deps           Build shared static library prefix for $(HOST_ARCH)"
 	@echo "  make build          Build all tools for host architecture ($(HOST_ARCH))"
 	@echo "  make build-mtr      Build specific tool for host architecture"
 	@echo "  make build-all      Build all tools for all architectures (amd64, arm64)"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Or use the included verification script:
 ### Build for Your Architecture
 
 ```bash
+# Build the shared static library prefix (openssl, zlib, nghttp2, ...)
+make deps
+
 # Build a specific tool for your current architecture
 make build-mtr
 make build-dig
@@ -169,6 +172,10 @@ make clean    # Remove build artifacts
 ```
 static-tools/
 ├── Makefile                    # Root build entry point
+├── deps/
+│   ├── Dockerfile              # SHA256-pinned static library prefix
+│   ├── Makefile
+│   └── versions.mk             # Library/toolchain tarball pins
 ├── tools/
 │   ├── mtr/
 │   │   ├── Dockerfile          # Static build configuration
@@ -220,11 +227,12 @@ To add a new tool (e.g., `dig`):
    DIG_SOURCE_SHA256 := <computed-hash>
    ```
 
-3. Create `tools/dig/Dockerfile` following the mtr pattern:
-   - Use Alpine with musl for static linking
-   - Pin base image by digest
-   - Verify source with `ADD --checksum`
+3. Create `tools/dig/Dockerfile` following the curl pattern:
+   - Use Alpine with musl for static linking, pinned by digest
+   - `COPY --from=deps` the shared static prefix (do not `apk add` C libraries)
+   - Verify source tarballs with SHA256
    - Compile with `-static` flags
+   - If the tool needs a new library, add it to `deps/` first
 
 4. Create `tools/dig/Makefile` with build targets
 
@@ -284,7 +292,8 @@ All dependencies are pinned for reproducibility:
 - **Base images**: Alpine pinned by SHA256 digest
 - **Source code**: Verified with SHA256 checksums
 - **GitHub Actions**: Pinned by commit SHA
-- **Build dependencies**: Pinned to specific Alpine package versions
+- **C libraries**: Built from upstream tarballs pinned by URL + SHA256 (`deps/versions.mk`)
+- **Compiler**: Alpine `build-base` / `linux-headers` on the digest-pinned base image (official `gcc` images are glibc/Debian-only)
 
 ### Verification
 

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -116,6 +116,41 @@ RUN wget -q "${NGHTTP2_URL}" -O nghttp2.tar.gz && \
     make install && \
     cd /src && rm -rf nghttp2.tar.gz nghttp2-${NGHTTP2_VERSION}
 
+# --- ncurses (wide-char static) ---
+ARG NCURSES_VERSION
+ARG NCURSES_URL
+ARG NCURSES_SHA256
+RUN wget -q "${NCURSES_URL}" -O ncurses.tar.gz && \
+    echo "${NCURSES_SHA256}  ncurses.tar.gz" | sha256sum -c - && \
+    tar xzf ncurses.tar.gz && \
+    cd ncurses-${NCURSES_VERSION} && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --without-shared \
+        --with-normal \
+        --without-debug \
+        --without-ada \
+        --without-cxx \
+        --without-cxx-binding \
+        --enable-widec \
+        --with-pkg-config-libdir="${PREFIX}/lib/pkgconfig" \
+        --enable-pc-files && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf ncurses.tar.gz ncurses-${NCURSES_VERSION}
+
+# --- libcap ---
+ARG LIBCAP_VERSION
+ARG LIBCAP_URL
+ARG LIBCAP_SHA256
+RUN wget -q "${LIBCAP_URL}" -O libcap.tar.gz && \
+    echo "${LIBCAP_SHA256}  libcap.tar.gz" | sha256sum -c - && \
+    tar xzf libcap.tar.gz && \
+    cd libcap-${LIBCAP_VERSION} && \
+    make -C libcap prefix="${PREFIX}" lib=lib SHARED=no GOLANG=no && \
+    make -C libcap prefix="${PREFIX}" lib=lib SHARED=no GOLANG=no install && \
+    cd /src && rm -rf libcap.tar.gz libcap-${LIBCAP_VERSION}
+
 # Drop perl from the exported prefix; tools only need headers and static libs.
 RUN rm -rf \
         "${PREFIX}/bin/perl" \
@@ -127,7 +162,9 @@ RUN rm -rf \
     test -f "${PREFIX}/lib/libssl.a" && \
     test -f "${PREFIX}/lib/libcrypto.a" && \
     test -f "${PREFIX}/lib/libz.a" && \
-    test -f "${PREFIX}/lib/libnghttp2.a"
+    test -f "${PREFIX}/lib/libnghttp2.a" && \
+    test -f "${PREFIX}/lib/libncursesw.a" && \
+    test -f "${PREFIX}/lib/libcap.a"
 
 FROM scratch AS export
 COPY --from=builder /opt/st /

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -14,7 +14,11 @@ ARG PREFIX=/opt/st
 # build-base and linux-headers have been stable across Alpine 3.21; they
 # provide gcc/make/strip/musl-dev. Do not apk-add openssl/zlib/nghttp2/perl.
 RUN apk add --no-cache \
+    autoconf=2.72-r0 \
+    automake=1.17-r0 \
     build-base=0.5-r3 \
+    bzip2=1.0.8-r6 \
+    libtool=2.4.7-r3 \
     linux-headers=6.6-r1
 
 ENV PATH="${PREFIX}/bin:${PATH}" \
@@ -151,6 +155,55 @@ RUN wget -q "${LIBCAP_URL}" -O libcap.tar.gz && \
     make -C libcap prefix="${PREFIX}" lib=lib SHARED=no GOLANG=no install && \
     cd /src && rm -rf libcap.tar.gz libcap-${LIBCAP_VERSION}
 
+# --- libuv ---
+ARG LIBUV_VERSION
+ARG LIBUV_URL
+ARG LIBUV_SHA256
+RUN wget -q "${LIBUV_URL}" -O libuv.tar.gz && \
+    echo "${LIBUV_SHA256}  libuv.tar.gz" | sha256sum -c - && \
+    tar xzf libuv.tar.gz && \
+    cd libuv-v${LIBUV_VERSION} && \
+    ./autogen.sh && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --disable-shared \
+        --enable-static && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf libuv.tar.gz libuv-v${LIBUV_VERSION}
+
+# --- userspace-rcu ---
+ARG URCU_VERSION
+ARG URCU_URL
+ARG URCU_SHA256
+RUN wget -q "${URCU_URL}" -O urcu.tar.bz2 && \
+    echo "${URCU_SHA256}  urcu.tar.bz2" | sha256sum -c - && \
+    tar xjf urcu.tar.bz2 && \
+    cd userspace-rcu-${URCU_VERSION} && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --disable-shared \
+        --enable-static && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf urcu.tar.bz2 userspace-rcu-${URCU_VERSION}
+
+# --- jemalloc ---
+ARG JEMALLOC_VERSION
+ARG JEMALLOC_URL
+ARG JEMALLOC_SHA256
+RUN wget -q "${JEMALLOC_URL}" -O jemalloc.tar.bz2 && \
+    echo "${JEMALLOC_SHA256}  jemalloc.tar.bz2" | sha256sum -c - && \
+    tar xjf jemalloc.tar.bz2 && \
+    cd jemalloc-${JEMALLOC_VERSION} && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --disable-shared \
+        --enable-static && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf jemalloc.tar.bz2 jemalloc-${JEMALLOC_VERSION}
+
 # Drop perl from the exported prefix; tools only need headers and static libs.
 RUN rm -rf \
         "${PREFIX}/bin/perl" \
@@ -164,7 +217,10 @@ RUN rm -rf \
     test -f "${PREFIX}/lib/libz.a" && \
     test -f "${PREFIX}/lib/libnghttp2.a" && \
     test -f "${PREFIX}/lib/libncursesw.a" && \
-    test -f "${PREFIX}/lib/libcap.a"
+    test -f "${PREFIX}/lib/libcap.a" && \
+    test -f "${PREFIX}/lib/libuv.a" && \
+    test -f "${PREFIX}/lib/liburcu.a" && \
+    test -f "${PREFIX}/lib/libjemalloc.a"
 
 FROM scratch AS export
 COPY --from=builder /opt/st /

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -86,7 +86,7 @@ RUN wget -q "${OPENSSL_URL}" -O openssl.tar.gz && \
     esac && \
     ./Configure \
         --prefix="${PREFIX}" \
-        --openssldir="${PREFIX}/ssl" \
+        --openssldir=/etc/ssl \
         --libdir=lib \
         no-shared \
         no-tests \

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -91,7 +91,7 @@ RUN wget -q "${OPENSSL_URL}" -O openssl.tar.gz && \
         no-shared \
         no-tests \
         no-docs \
-        zlib \
+        no-zlib \
         "${OPENSSL_TARGET}" && \
     make -j"$(nproc)" && \
     make install_sw && \

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1.7
+
+# Build a shared static prefix from SHA256-pinned upstream tarballs.
+# The only apk packages are the compiler toolchain; C libraries come from source.
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# build-base and linux-headers have been stable across Alpine 3.21; they
+# provide gcc/make/strip/musl-dev. Do not apk-add openssl/zlib/nghttp2/perl.
+RUN apk add --no-cache \
+    build-base=0.5-r3 \
+    linux-headers=6.6-r1
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+
+# --- perl (OpenSSL Configure) ---
+ARG PERL_VERSION
+ARG PERL_URL
+ARG PERL_SHA256
+RUN wget -q "${PERL_URL}" -O perl.tar.gz && \
+    echo "${PERL_SHA256}  perl.tar.gz" | sha256sum -c - && \
+    tar xzf perl.tar.gz && \
+    cd perl-${PERL_VERSION} && \
+    ./Configure -des \
+        -Dprefix="${PREFIX}" \
+        -Dman1dir=none \
+        -Dman3dir=none && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf perl.tar.gz perl-${PERL_VERSION}
+
+# --- pkg-config ---
+ARG PKG_CONFIG_VERSION
+ARG PKG_CONFIG_URL
+ARG PKG_CONFIG_SHA256
+RUN wget -q "${PKG_CONFIG_URL}" -O pkg-config.tar.gz && \
+    echo "${PKG_CONFIG_SHA256}  pkg-config.tar.gz" | sha256sum -c - && \
+    tar xzf pkg-config.tar.gz && \
+    cd pkg-config-${PKG_CONFIG_VERSION} && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --with-internal-glib \
+        --disable-host-tool \
+        --disable-shared && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf pkg-config.tar.gz pkg-config-${PKG_CONFIG_VERSION}
+
+# --- zlib ---
+ARG ZLIB_VERSION
+ARG ZLIB_URL
+ARG ZLIB_SHA256
+RUN wget -q "${ZLIB_URL}" -O zlib.tar.gz && \
+    echo "${ZLIB_SHA256}  zlib.tar.gz" | sha256sum -c - && \
+    tar xzf zlib.tar.gz && \
+    cd zlib-${ZLIB_VERSION} && \
+    ./configure --prefix="${PREFIX}" --static && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION}
+
+# --- openssl ---
+ARG OPENSSL_VERSION
+ARG OPENSSL_URL
+ARG OPENSSL_SHA256
+RUN wget -q "${OPENSSL_URL}" -O openssl.tar.gz && \
+    echo "${OPENSSL_SHA256}  openssl.tar.gz" | sha256sum -c - && \
+    tar xzf openssl.tar.gz && \
+    cd openssl-${OPENSSL_VERSION} && \
+    case "${TARGETARCH}" in \
+        amd64) OPENSSL_TARGET=linux-x86_64 ;; \
+        arm64) OPENSSL_TARGET=linux-aarch64 ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    ./Configure \
+        --prefix="${PREFIX}" \
+        --openssldir="${PREFIX}/ssl" \
+        --libdir=lib \
+        no-shared \
+        no-tests \
+        no-docs \
+        zlib \
+        "${OPENSSL_TARGET}" && \
+    make -j"$(nproc)" && \
+    make install_sw && \
+    cd /src && rm -rf openssl.tar.gz openssl-${OPENSSL_VERSION}
+
+# --- nghttp2 (library only) ---
+ARG NGHTTP2_VERSION
+ARG NGHTTP2_URL
+ARG NGHTTP2_SHA256
+RUN wget -q "${NGHTTP2_URL}" -O nghttp2.tar.gz && \
+    echo "${NGHTTP2_SHA256}  nghttp2.tar.gz" | sha256sum -c - && \
+    tar xzf nghttp2.tar.gz && \
+    cd nghttp2-${NGHTTP2_VERSION} && \
+    ./configure \
+        --prefix="${PREFIX}" \
+        --enable-lib-only \
+        --enable-static \
+        --disable-shared \
+        --disable-examples \
+        --disable-failmalloc && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /src && rm -rf nghttp2.tar.gz nghttp2-${NGHTTP2_VERSION}
+
+# Drop perl from the exported prefix; tools only need headers and static libs.
+RUN rm -rf \
+        "${PREFIX}/bin/perl" \
+        "${PREFIX}/bin/perl${PERL_VERSION}" \
+        "${PREFIX}/lib/perl5" \
+        "${PREFIX}/lib/pkgconfig/perl.pc" \
+        "${PREFIX}/man" \
+        "${PREFIX}/share/man" && \
+    test -f "${PREFIX}/lib/libssl.a" && \
+    test -f "${PREFIX}/lib/libcrypto.a" && \
+    test -f "${PREFIX}/lib/libz.a" && \
+    test -f "${PREFIX}/lib/libnghttp2.a"
+
+FROM scratch AS export
+COPY --from=builder /opt/st /

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -51,6 +51,15 @@ $(DEPS_OUT_DIR)/$(ARCH)/lib/libssl.a: Dockerfile versions.mk
 		--build-arg LIBCAP_VERSION=$(LIBCAP_VERSION) \
 		--build-arg LIBCAP_URL=$(LIBCAP_URL) \
 		--build-arg LIBCAP_SHA256=$(LIBCAP_SHA256) \
+		--build-arg LIBUV_VERSION=$(LIBUV_VERSION) \
+		--build-arg LIBUV_URL=$(LIBUV_URL) \
+		--build-arg LIBUV_SHA256=$(LIBUV_SHA256) \
+		--build-arg URCU_VERSION=$(URCU_VERSION) \
+		--build-arg URCU_URL=$(URCU_URL) \
+		--build-arg URCU_SHA256=$(URCU_SHA256) \
+		--build-arg JEMALLOC_VERSION=$(JEMALLOC_VERSION) \
+		--build-arg JEMALLOC_URL=$(JEMALLOC_URL) \
+		--build-arg JEMALLOC_SHA256=$(JEMALLOC_SHA256) \
 		--output type=local,dest=$(DEPS_OUT_DIR)/$(ARCH) \
 		--target export \
 		.

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,0 +1,67 @@
+# Shared static prefix built from upstream tarballs
+
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+
+OUT_DIR ?= $(CURDIR)/../dist
+DEPS_OUT_DIR := $(OUT_DIR)/deps
+
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: build
+build: $(DEPS_OUT_DIR)/$(ARCH)/lib/libssl.a
+
+$(DEPS_OUT_DIR)/$(ARCH)/lib/libssl.a: Dockerfile versions.mk
+	@mkdir -p $(DEPS_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg PREFIX=$(PREFIX) \
+		--build-arg PERL_VERSION=$(PERL_VERSION) \
+		--build-arg PERL_URL=$(PERL_URL) \
+		--build-arg PERL_SHA256=$(PERL_SHA256) \
+		--build-arg PKG_CONFIG_VERSION=$(PKG_CONFIG_VERSION) \
+		--build-arg PKG_CONFIG_URL=$(PKG_CONFIG_URL) \
+		--build-arg PKG_CONFIG_SHA256=$(PKG_CONFIG_SHA256) \
+		--build-arg ZLIB_VERSION=$(ZLIB_VERSION) \
+		--build-arg ZLIB_URL=$(ZLIB_URL) \
+		--build-arg ZLIB_SHA256=$(ZLIB_SHA256) \
+		--build-arg OPENSSL_VERSION=$(OPENSSL_VERSION) \
+		--build-arg OPENSSL_URL=$(OPENSSL_URL) \
+		--build-arg OPENSSL_SHA256=$(OPENSSL_SHA256) \
+		--build-arg NGHTTP2_VERSION=$(NGHTTP2_VERSION) \
+		--build-arg NGHTTP2_URL=$(NGHTTP2_URL) \
+		--build-arg NGHTTP2_SHA256=$(NGHTTP2_SHA256) \
+		--output type=local,dest=$(DEPS_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built static prefix for $(ARCH):"
+	@ls -la $(DEPS_OUT_DIR)/$(ARCH)/lib
+
+.PHONY: build-all
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+.PHONY: clean
+clean:
+	rm -rf $(DEPS_OUT_DIR)
+
+.PHONY: info
+info:
+	@echo "Static prefix: $(PREFIX)"
+	@echo "OpenSSL $(OPENSSL_VERSION)"
+	@echo "zlib $(ZLIB_VERSION)"
+	@echo "nghttp2 $(NGHTTP2_VERSION)"

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -45,6 +45,12 @@ $(DEPS_OUT_DIR)/$(ARCH)/lib/libssl.a: Dockerfile versions.mk
 		--build-arg NGHTTP2_VERSION=$(NGHTTP2_VERSION) \
 		--build-arg NGHTTP2_URL=$(NGHTTP2_URL) \
 		--build-arg NGHTTP2_SHA256=$(NGHTTP2_SHA256) \
+		--build-arg NCURSES_VERSION=$(NCURSES_VERSION) \
+		--build-arg NCURSES_URL=$(NCURSES_URL) \
+		--build-arg NCURSES_SHA256=$(NCURSES_SHA256) \
+		--build-arg LIBCAP_VERSION=$(LIBCAP_VERSION) \
+		--build-arg LIBCAP_URL=$(LIBCAP_URL) \
+		--build-arg LIBCAP_SHA256=$(LIBCAP_SHA256) \
 		--output type=local,dest=$(DEPS_OUT_DIR)/$(ARCH) \
 		--target export \
 		.

--- a/deps/versions.mk
+++ b/deps/versions.mk
@@ -38,4 +38,16 @@ LIBCAP_VERSION := 2.78
 LIBCAP_URL := https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-$(LIBCAP_VERSION).tar.gz
 LIBCAP_SHA256 := 856e742e331bb53176231e1eae3588ab044e5564c811df3138bd2f1c7b953682
 
+LIBUV_VERSION := 1.49.2
+LIBUV_URL := https://dist.libuv.org/dist/v$(LIBUV_VERSION)/libuv-v$(LIBUV_VERSION).tar.gz
+LIBUV_SHA256 := 8c10706bd2cf129045c42b94799a92df9aaa75d05f07e99cf083507239bae5a8
+
+URCU_VERSION := 0.14.1
+URCU_URL := https://lttng.org/files/urcu/userspace-rcu-$(URCU_VERSION).tar.bz2
+URCU_SHA256 := 231acb13dc6ec023e836a0f0666f6aab47dc621ecb1d2cd9d9c22f922678abc0
+
+JEMALLOC_VERSION := 5.3.0
+JEMALLOC_URL := https://github.com/jemalloc/jemalloc/releases/download/$(JEMALLOC_VERSION)/jemalloc-$(JEMALLOC_VERSION).tar.bz2
+JEMALLOC_SHA256 := 2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa
+
 PREFIX := /opt/st

--- a/deps/versions.mk
+++ b/deps/versions.mk
@@ -1,0 +1,33 @@
+# Shared static library prefix (built from upstream tarballs).
+# Official gcc images are Debian/glibc-only, so the compiler is Alpine's
+# musl gcc from a digest-pinned base image plus apk-pinned build-base
+# and linux-headers (those two have been stable on 3.21). C libraries
+# are NOT installed via apk; they are fetched by URL and verified with SHA256.
+
+ALPINE_VERSION := 3.21
+ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
+ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
+
+# Host tools built into the prefix (perl is required by OpenSSL Configure)
+PERL_VERSION := 5.40.2
+PERL_URL := https://www.cpan.org/src/5.0/perl-$(PERL_VERSION).tar.gz
+PERL_SHA256 := 10d4647cfbb543a7f9ae3e5f6851ec49305232ea7621aed24c7cfbb0bef4b70d
+
+PKG_CONFIG_VERSION := 0.29.2
+PKG_CONFIG_URL := https://pkg-config.freedesktop.org/releases/pkg-config-$(PKG_CONFIG_VERSION).tar.gz
+PKG_CONFIG_SHA256 := 6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+
+# Libraries
+ZLIB_VERSION := 1.3.2
+ZLIB_URL := https://github.com/madler/zlib/releases/download/v$(ZLIB_VERSION)/zlib-$(ZLIB_VERSION).tar.gz
+ZLIB_SHA256 := bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
+
+OPENSSL_VERSION := 3.3.7
+OPENSSL_URL := https://github.com/openssl/openssl/releases/download/openssl-$(OPENSSL_VERSION)/openssl-$(OPENSSL_VERSION).tar.gz
+OPENSSL_SHA256 := 4900be54e81c4dfe00bb1a10dad33fd8414833573c40d0e9e3274d4ed32e53a2
+
+NGHTTP2_VERSION := 1.69.0
+NGHTTP2_URL := https://github.com/nghttp2/nghttp2/releases/download/v$(NGHTTP2_VERSION)/nghttp2-$(NGHTTP2_VERSION).tar.gz
+NGHTTP2_SHA256 := c866b7477cbb7512ab6863a685027adbb1bb8da8fc3bab7429ed43d3281d5aa9
+
+PREFIX := /opt/st

--- a/deps/versions.mk
+++ b/deps/versions.mk
@@ -30,4 +30,12 @@ NGHTTP2_VERSION := 1.69.0
 NGHTTP2_URL := https://github.com/nghttp2/nghttp2/releases/download/v$(NGHTTP2_VERSION)/nghttp2-$(NGHTTP2_VERSION).tar.gz
 NGHTTP2_SHA256 := c866b7477cbb7512ab6863a685027adbb1bb8da8fc3bab7429ed43d3281d5aa9
 
+NCURSES_VERSION := 6.5
+NCURSES_URL := https://ftp.gnu.org/gnu/ncurses/ncurses-$(NCURSES_VERSION).tar.gz
+NCURSES_SHA256 := 136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6
+
+LIBCAP_VERSION := 2.78
+LIBCAP_URL := https://git.kernel.org/pub/scm/libs/libcap/libcap.git/snapshot/libcap-$(LIBCAP_VERSION).tar.gz
+LIBCAP_SHA256 := 856e742e331bb53176231e1eae3588ab044e5564c811df3138bd2f1c7b953682
+
 PREFIX := /opt/st

--- a/tools/curl/Dockerfile
+++ b/tools/curl/Dockerfile
@@ -1,48 +1,43 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG CURL_VERSION
 ARG CURL_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
-# Using static versions of required libraries for static linking
+# Compiler only. OpenSSL, zlib, and nghttp2 come from the SHA256-pinned prefix.
 RUN apk add --no-cache \
-    build-base=0.5-r3 \
-    linux-headers=6.6-r1 \
-    perl=5.40.4-r0 \
-    openssl-dev=3.3.7-r0 \
-    openssl-libs-static=3.3.7-r0 \
-    nghttp2-dev=1.69.0-r0 \
-    nghttp2-static=1.69.0-r0 \
-    zlib-dev=1.3.2-r0 \
-    zlib-static=1.3.2-r0 \
-    xz=5.8.3-r0
+    build-base=0.5-r3
 
-# Download and verify source
+# Additional context `deps` is the exported static prefix (see deps/Dockerfile).
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
 WORKDIR /src
-RUN wget -q "https://curl.se/download/curl-${CURL_VERSION}.tar.xz" -O curl.tar.xz && \
-    echo "${CURL_SOURCE_SHA256}  curl.tar.xz" | sha256sum -c -
+RUN wget -q "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" -O curl.tar.gz && \
+    echo "${CURL_SOURCE_SHA256}  curl.tar.gz" | sha256sum -c -
 
-# Extract and build curl
-RUN tar xf curl.tar.xz && \
+RUN tar xzf curl.tar.gz && \
     cd curl-${CURL_VERSION} && \
-    # Configure for static build with common protocols
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static" \
     ./configure \
         --prefix=/usr \
         --disable-shared \
         --enable-static \
-        --with-openssl \
-        --with-nghttp2 \
+        --with-openssl="${PREFIX}" \
+        --with-nghttp2="${PREFIX}" \
+        --with-zlib="${PREFIX}" \
+        --with-ca-path=/etc/ssl/certs \
+        --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
         --without-brotli \
         --without-libidn2 \
         --without-libpsl \
@@ -61,16 +56,12 @@ RUN tar xf curl.tar.xz && \
         --disable-mqtt \
         --disable-manual \
         --disable-docs && \
-    make -j"$(nproc)" LDFLAGS="-static -all-static" && \
-    # Copy binary to output
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static -all-static" && \
     mkdir -p /out && \
     cp src/curl /out/curl && \
     strip /out/curl && \
-    # Verify it's statically linked
     file /out/curl | grep -q "statically linked" && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/curl/Makefile
+++ b/tools/curl/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/curl
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-curl-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/curl
 
-$(TOOL_OUT_DIR)/$(ARCH)/curl: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/curl: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg CURL_VERSION=$(CURL_VERSION) \
@@ -45,6 +51,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/curl: Dockerfile versions.mk
 		.
 	@echo "Built curl $(CURL_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build for all architectures
 .PHONY: build-all
@@ -66,21 +75,21 @@ test: build
 	@# Run curl --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/curl:/curl:ro \
-		alpine:$(ALPINE_VERSION) /curl --version 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /curl --version 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "curl" || \
 		(echo "ERROR: curl --version failed" && exit 1)
 	@echo "✓ curl --version works"
 	@# Run curl --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/curl:/curl:ro \
-		alpine:$(ALPINE_VERSION) /curl --help 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /curl --help 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage" || \
 		(echo "ERROR: curl --help failed" && exit 1)
 	@echo "✓ curl --help works"
 	@# Run a basic HTTP request
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/curl:/curl:ro \
-		alpine:$(ALPINE_VERSION) /curl -s -o /dev/null -w "%{http_code}" https://example.com 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /curl -s -o /dev/null -w "%{http_code}" https://example.com 2>&1) && \
 		echo "$$OUTPUT" | grep -q "200" || \
 		(echo "ERROR: curl HTTP request failed" && exit 1)
 	@echo "✓ curl HTTP request works"

--- a/tools/curl/versions.mk
+++ b/tools/curl/versions.mk
@@ -1,17 +1,9 @@
 # curl version and checksums
 # All versions and checksums should be pinned for reproducibility
 
-# curl source
+include ../../deps/versions.mk
+
+# curl source (tar.gz so the tool build does not need xz)
 CURL_VERSION := 8.11.1
-CURL_SOURCE_URL := https://curl.se/download/curl-$(CURL_VERSION).tar.xz
-CURL_SOURCE_SHA256 := c7ca7db48b0909743eaef34250da02c19bc61d4f1dcedd6603f109409536ab56
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef
+CURL_SOURCE_URL := https://curl.se/download/curl-$(CURL_VERSION).tar.gz
+CURL_SOURCE_SHA256 := a889ac9dbba3644271bd9d1302b5c22a088893719b72be3487bc3d401e5c4e80

--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -1,76 +1,56 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG BIND9_VERSION
 ARG BIND9_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
-# Using static versions of required libraries for static linking
+# Compiler + xz for the BIND tarball. C libraries come from the SHA256-pinned prefix.
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    perl=5.40.4-r0 \
-    libuv-dev=1.49.2-r0 \
-    libuv-static=1.49.2-r0 \
-    userspace-rcu-dev=0.14.1-r1 \
-    userspace-rcu-static=0.14.1-r1 \
-    nghttp2-dev=1.69.0-r0 \
-    nghttp2-static=1.69.0-r0 \
-    openssl-dev=3.3.7-r0 \
-    openssl-libs-static=3.3.7-r0 \
-    libcap-dev=2.78-r0 \
-    libcap-static=2.78-r0 \
-    jemalloc-dev=5.3.0-r6 \
-    jemalloc-static=5.3.0-r6 \
     xz=5.8.3-r0
 
-# Download and verify source
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-static -Os -fstack-protector-strong"
+
 WORKDIR /src
 RUN wget -q "https://downloads.isc.org/isc/bind9/${BIND9_VERSION}/bind-${BIND9_VERSION}.tar.xz" -O bind.tar.xz && \
     echo "${BIND9_SOURCE_SHA256}  bind.tar.xz" | sha256sum -c -
 
-# Extract and build dig
-# BIND 9.16.x is the last version using autoconf that allows static compilation
-# Newer versions use Meson and explicitly disable static linking
+# BIND 9.16.x is the last autoconf version that allows static compilation.
 RUN tar xf bind.tar.xz && \
     cd bind-${BIND9_VERSION} && \
-    # Configure for static build
-    # --disable-linux-caps: Avoids libcap dynamic linking issues
-    # --disable-symtable: Removes symbol table which may use dlopen
-    # --disable-backtrace: Removes backtrace which may use dynamic features
-    # --without-python: Avoids python bindings that prevent static linking
-    CFLAGS="-static -Os -fstack-protector-strong" \
-    LDFLAGS="-static" \
     ./configure \
         --without-python \
         --disable-symtable \
         --disable-backtrace \
-        --disable-linux-caps && \
-    # Build only the libraries needed for dig
+        --disable-linux-caps \
+        --with-openssl="${PREFIX}" \
+        --with-libxml2=no \
+        --with-libuv="${PREFIX}" \
+        --with-nghttp2="${PREFIX}" && \
     cd lib/dns/ && make -j"$(nproc)" && \
     cd ../bind9/ && make -j"$(nproc)" && \
     cd ../isc && make -j"$(nproc)" && \
     cd ../isccfg/ && make -j"$(nproc)" && \
     cd ../irs/ && make -j"$(nproc)" && \
-    # Build dig
     cd ../../bin/dig && make -j"$(nproc)" && \
-    # Copy binary to output
     mkdir -p /out && \
     cp dig /out/dig && \
     strip /out/dig && \
-    # Verify it's statically linked
     file /out/dig | grep -q "statically linked" && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/dig/Makefile
+++ b/tools/dig/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/dig
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-dig-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/dig
 
-$(TOOL_OUT_DIR)/$(ARCH)/dig: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/dig: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libuv.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg BIND9_VERSION=$(BIND9_VERSION) \
@@ -45,6 +51,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/dig: Dockerfile versions.mk
 		.
 	@echo "Built dig (from BIND $(BIND9_VERSION)) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libuv.a $(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build for all architectures
 .PHONY: build-all
@@ -66,21 +75,21 @@ test: build
 	@# Run dig -v in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/dig:/dig:ro \
-		alpine:$(ALPINE_VERSION) /dig -v 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /dig -v 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "dig" || \
 		(echo "ERROR: dig -v failed" && exit 1)
 	@echo "✓ dig -v works"
 	@# Run dig -h in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/dig:/dig:ro \
-		alpine:$(ALPINE_VERSION) /dig -h 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /dig -h 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage" || \
 		(echo "ERROR: dig -h failed" && exit 1)
 	@echo "✓ dig -h works"
 	@# Run a basic DNS query
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/dig:/dig:ro \
-		alpine:$(ALPINE_VERSION) /dig @1.1.1.1 example.com A +short 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /dig @1.1.1.1 example.com A +short 2>&1) && \
 		echo "$$OUTPUT" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" || \
 		(echo "ERROR: dig DNS query failed" && exit 1)
 	@echo "✓ dig DNS query works"

--- a/tools/dig/versions.mk
+++ b/tools/dig/versions.mk
@@ -2,18 +2,10 @@
 # All versions and checksums should be pinned for reproducibility
 # Note: Using BIND 9.16.x (last autoconf-based version) which allows static compilation
 
+include ../../deps/versions.mk
+
 # BIND source (provides dig)
 # 9.16.x is the last version using autoconf - newer versions use Meson and don't support static linking
 BIND9_VERSION := 9.16.50
 BIND9_SOURCE_URL := https://downloads.isc.org/isc/bind9/$(BIND9_VERSION)/bind-$(BIND9_VERSION).tar.xz
 BIND9_SOURCE_SHA256 := 816dbaa3c115019f30fcebd9e8ef8f7637f4adde91c79daa099b035255a15795
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef

--- a/tools/drill/Dockerfile
+++ b/tools/drill/Dockerfile
@@ -1,60 +1,56 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG LDNS_VERSION
 ARG LDNS_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
-# ldns provides drill which is a dig-like tool that can be statically compiled
+# Compiler only. OpenSSL comes from the SHA256-pinned prefix.
 RUN apk add --no-cache \
     build-base=0.5-r3 \
-    linux-headers=6.6-r1 \
-    openssl-dev=3.3.7-r0 \
-    openssl-libs-static=3.3.7-r0
+    linux-headers=6.6-r1
 
-# Download and verify source
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
 WORKDIR /src
 RUN wget -q "https://nlnetlabs.nl/downloads/ldns/ldns-${LDNS_VERSION}.tar.gz" -O ldns.tar.gz && \
     echo "${LDNS_SOURCE_SHA256}  ldns.tar.gz" | sha256sum -c -
 
-# Extract and build drill (dig alternative)
 RUN tar xzf ldns.tar.gz && \
     cd ldns-${LDNS_VERSION} && \
-    # Configure for static build
+    LIBS="-lcrypto -ldl -pthread" \
     ./configure \
         --prefix=/usr \
         --disable-shared \
         --enable-static \
         --with-drill \
+        --with-ssl="${PREFIX}" \
         --disable-dane \
         --disable-dane-ta-usage \
         CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" && \
-    # Build library only first
     make -j"$(nproc)" && \
-    # Now re-link drill with -all-static flag
     cd drill && \
     ../libtool --tag=CC --mode=link gcc -all-static -s -Os \
         -o drill \
         chasetrace.lo dnssec.lo drill.lo drill_util.lo \
         error.lo root.lo securetrace.lo work.lo \
         ../compat/b64_pton.lo ../compat/b64_ntop.lo \
-        ../libldns.la -lcrypto && \
-    # Copy binary to output
+        ../libldns.la -L${PREFIX}/lib -lcrypto -ldl -pthread && \
     mkdir -p /out && \
     cp .libs/drill /out/drill 2>/dev/null || cp drill /out/drill && \
-    # Verify it's statically linked (file output shows "statically linked")
     file /out/drill | grep -q "statically linked" && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/drill/Makefile
+++ b/tools/drill/Makefile
@@ -49,11 +49,11 @@ $(TOOL_OUT_DIR)/$(ARCH)/drill: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+	@echo "Built drill (from ldns $(LDNS_VERSION)) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 $(DEPS_PREFIX)/lib/libssl.a:
 	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
-	@echo "Built drill (from ldns $(LDNS_VERSION)) for $(ARCH):"
-	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 # Build for all architectures
 .PHONY: build-all

--- a/tools/drill/Makefile
+++ b/tools/drill/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/drill
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-drill-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/drill
 
-$(TOOL_OUT_DIR)/$(ARCH)/drill: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/drill: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg LDNS_VERSION=$(LDNS_VERSION) \
@@ -43,6 +49,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/drill: Dockerfile versions.mk
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 	@echo "Built drill (from ldns $(LDNS_VERSION)) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
@@ -66,21 +75,21 @@ test: build
 	@# Run drill -v in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/drill:/drill:ro \
-		alpine:$(ALPINE_VERSION) /drill -v 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /drill -v 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "version" || \
 		(echo "ERROR: drill -v failed" && exit 1)
 	@echo "✓ drill -v works"
 	@# Run drill -h in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/drill:/drill:ro \
-		alpine:$(ALPINE_VERSION) /drill -h 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /drill -h 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "Usage" || \
 		(echo "ERROR: drill -h failed" && exit 1)
 	@echo "✓ drill -h works"
 	@# Run a basic DNS query
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/drill:/drill:ro \
-		alpine:$(ALPINE_VERSION) /drill @1.1.1.1 example.com A 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /drill @1.1.1.1 example.com A 2>&1) && \
 		echo "$$OUTPUT" | grep -q "ANSWER SECTION" || \
 		(echo "ERROR: drill DNS query failed" && exit 1)
 	@echo "✓ drill DNS query works"

--- a/tools/drill/versions.mk
+++ b/tools/drill/versions.mk
@@ -1,18 +1,9 @@
-# dig (drill) version and checksums
+# drill (ldns) version and checksums
 # All versions and checksums should be pinned for reproducibility
-# Note: We use ldns/drill instead of BIND dig because BIND cannot be statically compiled
+
+include ../../deps/versions.mk
 
 # ldns source (provides drill, a dig-like DNS tool)
 LDNS_VERSION := 1.8.4
 LDNS_SOURCE_URL := https://nlnetlabs.nl/downloads/ldns/ldns-$(LDNS_VERSION).tar.gz
 LDNS_SOURCE_SHA256 := 838b907594baaff1cd767e95466a7745998ae64bc74be038dccc62e2de2e4247
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef

--- a/tools/iperf3/Dockerfile
+++ b/tools/iperf3/Dockerfile
@@ -1,52 +1,48 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG IPERF3_VERSION
 ARG IPERF3_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
-# Using static versions of required libraries for static linking
+# Compiler only. OpenSSL comes from the SHA256-pinned prefix.
 RUN apk add --no-cache \
     build-base=0.5-r3 \
-    linux-headers=6.6-r1 \
-    openssl-dev=3.3.7-r0 \
-    openssl-libs-static=3.3.7-r0
+    linux-headers=6.6-r1
 
-# Download and verify source
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
 WORKDIR /src
 RUN wget -q "https://github.com/esnet/iperf/releases/download/${IPERF3_VERSION}/iperf-${IPERF3_VERSION}.tar.gz" -O iperf3.tar.gz && \
     echo "${IPERF3_SOURCE_SHA256}  iperf3.tar.gz" | sha256sum -c -
 
-# Extract and build iperf3
 RUN tar xzf iperf3.tar.gz && \
     cd iperf-${IPERF3_VERSION} && \
-    # Configure for static build
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static" \
+    LIBS="-lssl -lcrypto -lz -ldl -pthread" \
     ./configure \
         --prefix=/usr \
         --disable-shared \
         --enable-static \
         --enable-static-bin \
-        --with-openssl=/usr && \
+        --with-openssl="${PREFIX}" && \
     make -j"$(nproc)" && \
-    # Copy binary to output
     mkdir -p /out && \
     cp src/iperf3 /out/iperf3 && \
     strip /out/iperf3 && \
-    # Verify it's statically linked
+    file /out/iperf3 && \
     file /out/iperf3 | grep -q "statically linked" && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/iperf3/Makefile
+++ b/tools/iperf3/Makefile
@@ -49,11 +49,11 @@ $(TOOL_OUT_DIR)/$(ARCH)/iperf3: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+	@echo "Built iperf3 $(IPERF3_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 $(DEPS_PREFIX)/lib/libssl.a:
 	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
-	@echo "Built iperf3 $(IPERF3_VERSION) for $(ARCH):"
-	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 # Build for all architectures
 .PHONY: build-all

--- a/tools/iperf3/Makefile
+++ b/tools/iperf3/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/iperf3
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-iperf3-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/iperf3
 
-$(TOOL_OUT_DIR)/$(ARCH)/iperf3: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/iperf3: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg IPERF3_VERSION=$(IPERF3_VERSION) \
@@ -43,6 +49,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/iperf3: Dockerfile versions.mk
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 	@echo "Built iperf3 $(IPERF3_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
@@ -66,14 +75,14 @@ test: build
 	@# Run iperf3 --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/iperf3:/iperf3:ro \
-		alpine:$(ALPINE_VERSION) /iperf3 --version 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /iperf3 --version 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "iperf" || \
 		(echo "ERROR: iperf3 --version failed" && exit 1)
 	@echo "✓ iperf3 --version works"
 	@# Run iperf3 --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/iperf3:/iperf3:ro \
-		alpine:$(ALPINE_VERSION) /iperf3 --help 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /iperf3 --help 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage" || \
 		(echo "ERROR: iperf3 --help failed" && exit 1)
 	@echo "✓ iperf3 --help works"

--- a/tools/iperf3/versions.mk
+++ b/tools/iperf3/versions.mk
@@ -1,17 +1,9 @@
 # iperf3 version and checksums
 # All versions and checksums should be pinned for reproducibility
 
+include ../../deps/versions.mk
+
 # iperf3 source
 IPERF3_VERSION := 3.18
 IPERF3_SOURCE_URL := https://github.com/esnet/iperf/releases/download/$(IPERF3_VERSION)/iperf-$(IPERF3_VERSION).tar.gz
 IPERF3_SOURCE_SHA256 := c0618175514331e766522500e20c94bfb293b4424eb27d7207fb427b88d20bab
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef

--- a/tools/mtr/Dockerfile
+++ b/tools/mtr/Dockerfile
@@ -1,34 +1,34 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG MTR_VERSION
 ARG MTR_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
+# Compiler + autotools. ncurses and libcap come from the SHA256-pinned prefix.
 RUN apk add --no-cache \
     autoconf=2.72-r0 \
     automake=1.17-r0 \
     build-base=0.5-r3 \
-    libcap-dev=2.78-r0 \
-    libcap-static=2.78-r0 \
-    linux-headers=6.6-r1 \
-    ncurses-dev=6.5_p20241006-r3 \
-    ncurses-static=6.5_p20241006-r3
+    linux-headers=6.6-r1
 
-# Download and verify source (wget is included in Alpine base image)
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
 WORKDIR /src
 RUN wget -q "https://github.com/traviscross/mtr/archive/refs/tags/v${MTR_VERSION}.tar.gz" -O mtr.tar.gz && \
     echo "${MTR_SOURCE_SHA256}  mtr.tar.gz" | sha256sum -c -
 
-# Extract and build
 RUN tar xzf mtr.tar.gz && \
     cd mtr-${MTR_VERSION} && \
     ./bootstrap.sh && \
@@ -36,17 +36,13 @@ RUN tar xzf mtr.tar.gz && \
         --without-gtk \
         --without-jansson \
         CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-        LDFLAGS="-static -s" && \
+        LDFLAGS="-L${PREFIX}/lib -static -s" && \
     make -j"$(nproc)" && \
-    # Verify binaries are statically linked
     file mtr | grep -q "statically linked" && \
     file mtr-packet | grep -q "statically linked" && \
-    # Copy to output directory
     mkdir -p /out && \
     cp mtr mtr-packet /out/ && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/mtr/Makefile
+++ b/tools/mtr/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/mtr
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-mtr-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet
 
-$(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libncursesw.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg MTR_VERSION=$(MTR_VERSION) \
@@ -45,6 +51,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet: Dockerfile versi
 		.
 	@echo "Built mtr $(MTR_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libncursesw.a $(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build for all architectures
 .PHONY: build-all
@@ -66,14 +75,14 @@ test: build
 	@# Run mtr --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr:/mtr:ro \
-		alpine:$(ALPINE_VERSION) /mtr --version 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /mtr --version 2>&1) && \
 		echo "$$OUTPUT" | grep -q "mtr" || \
 		(echo "ERROR: mtr --version failed" && exit 1)
 	@echo "✓ mtr --version works"
 	@# Run mtr --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr:/mtr:ro \
-		alpine:$(ALPINE_VERSION) /mtr --help 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /mtr --help 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage\|options\|hostname" || \
 		(echo "ERROR: mtr --help failed" && exit 1)
 	@echo "✓ mtr --help works"

--- a/tools/mtr/versions.mk
+++ b/tools/mtr/versions.mk
@@ -1,18 +1,9 @@
 # mtr version and checksums
 # All versions and checksums should be pinned for reproducibility
 
+include ../../deps/versions.mk
+
 # mtr source
 MTR_VERSION := 0.95
 MTR_SOURCE_URL := https://github.com/traviscross/mtr/archive/refs/tags/v$(MTR_VERSION).tar.gz
 MTR_SOURCE_SHA256 := 12490fb660ba5fb34df8c06a0f62b4f9cbd11a584fc3f6eceda0a99124e8596f
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-# Usage: $(call alpine_image,amd64) => alpine:3.21@sha256:...
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef

--- a/tools/wget/Dockerfile
+++ b/tools/wget/Dockerfile
@@ -1,56 +1,48 @@
 # syntax=docker/dockerfile:1.7
 
-# Build arguments
 ARG ALPINE_VERSION=3.21
 ARG ALPINE_DIGEST
 
-# Use Alpine with musl libc for fully static binaries
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 
-# Build arguments available in build stage
 ARG WGET_VERSION
 ARG WGET_SOURCE_SHA256
 ARG TARGETARCH
+ARG PREFIX=/opt/st
 
-# Install build dependencies
-# Using static versions of required libraries for static linking
+# Compiler only. OpenSSL and zlib come from the SHA256-pinned prefix.
 RUN apk add --no-cache \
-    build-base=0.5-r3 \
-    linux-headers=6.6-r1 \
-    perl=5.40.4-r0 \
-    openssl-dev=3.3.7-r0 \
-    openssl-libs-static=3.3.7-r0 \
-    zlib-dev=1.3.2-r0 \
-    zlib-static=1.3.2-r0
+    build-base=0.5-r3
 
-# Download and verify source
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
 WORKDIR /src
 RUN wget -q "https://ftp.gnu.org/gnu/wget/wget-${WGET_VERSION}.tar.gz" -O wget.tar.gz && \
     echo "${WGET_SOURCE_SHA256}  wget.tar.gz" | sha256sum -c -
 
-# Extract and build wget
 RUN tar xzf wget.tar.gz && \
     cd wget-${WGET_VERSION} && \
-    # Configure for static build
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static" \
     ./configure \
         --prefix=/usr \
         --with-ssl=openssl \
+        --with-libssl-prefix="${PREFIX}" \
+        --with-zlib="${PREFIX}" \
         --without-libidn \
         --disable-nls \
         --disable-pcre \
         --disable-iri && \
-    make -j"$(nproc)" && \
-    # Copy binary to output
+    make -j"$(nproc)" SUBDIRS="lib src" LDFLAGS="-L${PREFIX}/lib -static" && \
     mkdir -p /out && \
     cp src/wget /out/wget && \
     strip /out/wget && \
-    # Verify it's statically linked
     file /out/wget | grep -q "statically linked" && \
-    # Generate checksums
     cd /out && sha256sum * > SHA256SUMS
 
-# Export stage - minimal image with just the binaries
 FROM scratch AS export
 COPY --from=builder /out/ /

--- a/tools/wget/Makefile
+++ b/tools/wget/Makefile
@@ -17,6 +17,7 @@ BUILDX ?= $(DOCKER) buildx
 # Output directory
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/wget
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 
 # Image name for intermediate builds
 IMAGE_NAME := static-tools-wget-builder
@@ -29,13 +30,18 @@ PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
+.PHONY: deps
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/wget
 
-$(TOOL_OUT_DIR)/$(ARCH)/wget: Dockerfile versions.mk
+$(TOOL_OUT_DIR)/$(ARCH)/wget: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg WGET_VERSION=$(WGET_VERSION) \
@@ -43,6 +49,9 @@ $(TOOL_OUT_DIR)/$(ARCH)/wget: Dockerfile versions.mk
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 	@echo "Built wget $(WGET_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
@@ -66,21 +75,21 @@ test: build
 	@# Run wget --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/wget:/wget:ro \
-		alpine:$(ALPINE_VERSION) /wget --version 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /wget --version 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "wget" || \
 		(echo "ERROR: wget --version failed" && exit 1)
 	@echo "✓ wget --version works"
 	@# Run wget --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/wget:/wget:ro \
-		alpine:$(ALPINE_VERSION) /wget --help 2>&1) && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /wget --help 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage" || \
 		(echo "ERROR: wget --help failed" && exit 1)
 	@echo "✓ wget --help works"
 	@# Run a basic HTTP request
 	@$(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/wget:/wget:ro \
-		alpine:$(ALPINE_VERSION) /wget -q --spider https://example.com && \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /wget -q --spider https://example.com && \
 		echo "✓ wget HTTP request works" || \
 		(echo "ERROR: wget HTTP request failed" && exit 1)
 	@echo "==> All wget tests passed"

--- a/tools/wget/Makefile
+++ b/tools/wget/Makefile
@@ -49,11 +49,11 @@ $(TOOL_OUT_DIR)/$(ARCH)/wget: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
 		--target export \
 		.
+	@echo "Built wget $(WGET_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 $(DEPS_PREFIX)/lib/libssl.a:
 	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
-	@echo "Built wget $(WGET_VERSION) for $(ARCH):"
-	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
 # Build for all architectures
 .PHONY: build-all

--- a/tools/wget/versions.mk
+++ b/tools/wget/versions.mk
@@ -1,17 +1,9 @@
 # wget version and checksums
 # All versions and checksums should be pinned for reproducibility
 
+include ../../deps/versions.mk
+
 # wget source
 WGET_VERSION := 1.25.0
 WGET_SOURCE_URL := https://ftp.gnu.org/gnu/wget/wget-$(WGET_VERSION).tar.gz
 WGET_SOURCE_SHA256 := 766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784
-
-# Alpine base image (pinned by digest for reproducibility)
-ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
-
-# Image reference helper (use digest for the target architecture)
-define alpine_image
-alpine:$(ALPINE_VERSION)@$(if $(filter amd64,$(1)),$(ALPINE_DIGEST_AMD64),$(ALPINE_DIGEST_ARM64))
-endef


### PR DESCRIPTION
## Summary

Alpine's live `apk` index rotates pinned C-library versions and breaks CI (see #3). This switches every tool off Alpine library packages and onto a shared musl prefix (`deps/`) compiled from upstream tarballs with URL + SHA256 pins.

Each tool is its own commit so the conversion is reviewable in order:

1. Shared prefix + curl (`zlib`, OpenSSL, `nghttp2`)
2. wget (OpenSSL `--openssldir=/etc/ssl` so static binaries use the host CA store)
3. iperf3
4. drill (OpenSSL rebuilt with `no-zlib` so static `libcrypto` does not require `-lz`)
5. mtr (`ncurses`, `libcap`)
6. dig (`libuv`, userspace-rcu, jemalloc)

The compiler stays Alpine `build-base` on a digest-pinned 3.21 image. C libraries are no longer installed via `apk`.

## Test plan

- [x] `make lint`
- [x] `make test-curl` (and wget / iperf3 / drill / mtr / dig during conversion)
- [x] CI `build-and-test` green on amd64 and arm64