### PR TITLE
Add socat, jq, fping, strace, ncdu, file, xxd, and htop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [mtr, dig, drill, curl, wget, iperf3, tcpdump, ncat, openssl, rsync]
+        tool: [mtr, dig, drill, curl, wget, iperf3, tcpdump, ncat, openssl, rsync, socat, jq, fping, strace, ncdu, file, xxd, htop]
         arch: [amd64, arm64]
         include:
           - arch: amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: [mtr, drill, dig, curl, wget, iperf3, tcpdump, ncat, openssl, rsync]
+        tool: [mtr, drill, dig, curl, wget, iperf3, tcpdump, ncat, openssl, rsync, socat, jq, fping, strace, ncdu, file, xxd, htop]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -73,6 +73,10 @@ jobs:
               mv "$file" "$file-${{ matrix.arch }}"
             done
             sha256sum mtr-${{ matrix.arch }} mtr-packet-${{ matrix.arch }} > SHA256SUMS-${{ matrix.arch }}.txt
+          elif [ "${{ matrix.tool }}" = "file" ]; then
+            mv file "file-${{ matrix.arch }}"
+            mv magic.mgc "magic.mgc-${{ matrix.arch }}"
+            sha256sum "file-${{ matrix.arch }}" "magic.mgc-${{ matrix.arch }}" > SHA256SUMS-${{ matrix.arch }}.txt
           else
             mv ${{ matrix.tool }} ${{ matrix.tool }}-${{ matrix.arch }}
             sha256sum ${{ matrix.tool }}-${{ matrix.arch }} > SHA256SUMS-${{ matrix.arch }}.txt

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILDX ?= $(DOCKER) buildx
 OUT_DIR := $(CURDIR)/dist
 
 # All tools
-TOOLS := mtr drill dig curl wget iperf3 tcpdump ncat openssl rsync
+TOOLS := mtr drill dig curl wget iperf3 tcpdump ncat openssl rsync socat jq fping strace ncdu file xxd htop
 
 # Versioning Format: YYYY.MM.MINOR
 # YYYY = year, MM = zero-padded month, MINOR = release number within month

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ SLSA 3+ provenance. For now that is left up to the user.
 | ncat | 7.991 | nmap netcat with SSL |
 | openssl | 3.3.7 | Cryptography command-line tool |
 | rsync | 3.5.0 | Fast incremental file-copying tool |
+| socat | 1.8.1.3 | Multipurpose relay (SOcket CAT) |
+| jq | 1.8.2 | Command-line JSON processor |
+| fping | 5.4 | Ping multiple hosts in parallel |
+| strace | 6.17 | System-call tracer |
+| ncdu | 1.22 | NCurses disk-usage analyzer |
+| file | 5.46 | File type identification (includes magic.mgc) |
+| xxd | 1.3.16 | Hex dump utility (tinyxxd) |
+| htop | 3.5.3 | Interactive process viewer |
 
 Each tool lives in `tools/<name>/` with its version pinned in `versions.mk`. Release artifacts are named `<tool>-<arch>` (for example `curl-amd64`).
 

--- a/tools/file/Dockerfile
+++ b/tools/file/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG FILE_VERSION
+ARG FILE_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# Compiler only. zlib comes from the SHA256-pinned prefix.
+RUN apk add --no-cache \
+    build-base=0.5-r3
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://astron.com/pub/file/file-${FILE_VERSION}.tar.gz" -O file.tar.gz && \
+    echo "${FILE_SOURCE_SHA256}  file.tar.gz" | sha256sum -c -
+
+# magic.mgc is required at runtime; ship it next to the binary.
+RUN tar xzf file.tar.gz && \
+    cd file-${FILE_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --disable-shared \
+        --enable-static \
+        --enable-zlib \
+        --disable-bzlib \
+        --disable-xzlib \
+        --disable-zstdlib \
+        --disable-lzlib \
+        --disable-libseccomp && \
+    make -j"$(nproc)" && \
+    mkdir -p /out && \
+    gcc -static -o /out/file src/file.o src/seccomp.o src/.libs/libmagic.a -L${PREFIX}/lib -lz && \
+    cp magic/magic.mgc /out/magic.mgc && \
+    strip /out/file && \
+    /usr/bin/file /out/file | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/file/Makefile
+++ b/tools/file/Makefile
@@ -1,0 +1,74 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/file
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/file $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc
+
+$(TOOL_OUT_DIR)/$(ARCH)/file $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libz.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg FILE_VERSION=$(FILE_VERSION) \
+		--build-arg FILE_SOURCE_SHA256=$(FILE_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built file $(FILE_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libz.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing file binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/file || (echo "ERROR: file binary not found" && exit 1)
+	@test -f $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc || (echo "ERROR: magic.mgc not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/file | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/file:/file:ro \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc:/magic.mgc:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /file --version 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "file" || (echo "ERROR: file --version failed: $$OUTPUT" && exit 1)
+	@echo "✓ file --version works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/file:/file:ro \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc:/magic.mgc:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /file -m /magic.mgc /file 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "elf\|executable" || (echo "ERROR: file identify failed: $$OUTPUT" && exit 1)
+	@echo "✓ file can identify an ELF binary"
+	@echo "==> All file tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/file
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: file $(FILE_VERSION)"
+	@echo "URL: $(FILE_SOURCE_URL)"
+	@echo "SHA256: $(FILE_SOURCE_SHA256)"

--- a/tools/file/versions.mk
+++ b/tools/file/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+FILE_VERSION := 5.46
+FILE_SOURCE_URL := https://astron.com/pub/file/file-$(FILE_VERSION).tar.gz
+FILE_SOURCE_SHA256 := c9cc77c7c560c543135edc555af609d5619dbef011997e988ce40a3d75d86088

--- a/tools/fping/Dockerfile
+++ b/tools/fping/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG FPING_VERSION
+ARG FPING_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+RUN apk add --no-cache \
+    build-base=0.5-r3
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://github.com/schweikert/fping/releases/download/v${FPING_VERSION}/fping-${FPING_VERSION}.tar.gz" -O fping.tar.gz && \
+    echo "${FPING_SOURCE_SHA256}  fping.tar.gz" | sha256sum -c -
+
+RUN tar xzf fping.tar.gz && \
+    cd fping-${FPING_VERSION} && \
+    ./configure --prefix=/usr && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    mkdir -p /out && \
+    cp src/fping /out/fping && \
+    strip /out/fping && \
+    file /out/fping | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/fping/Makefile
+++ b/tools/fping/Makefile
@@ -1,0 +1,71 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/fping
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/fping
+
+$(TOOL_OUT_DIR)/$(ARCH)/fping: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg FPING_VERSION=$(FPING_VERSION) \
+		--build-arg FPING_SOURCE_SHA256=$(FPING_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built fping $(FPING_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing fping binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/fping || (echo "ERROR: fping binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/fping | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/fping:/fping:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /fping -v 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "fping" || (echo "ERROR: fping -v failed: $$OUTPUT" && exit 1)
+	@echo "✓ fping -v works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/fping:/fping:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /fping -h 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "usage\|fping" || (echo "ERROR: fping -h failed: $$OUTPUT" && exit 1)
+	@echo "✓ fping -h works"
+	@echo "==> All fping tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/fping
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: fping $(FPING_VERSION)"
+	@echo "URL: $(FPING_SOURCE_URL)"
+	@echo "SHA256: $(FPING_SOURCE_SHA256)"

--- a/tools/fping/versions.mk
+++ b/tools/fping/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+FPING_VERSION := 5.4
+FPING_SOURCE_URL := https://github.com/schweikert/fping/releases/download/v$(FPING_VERSION)/fping-$(FPING_VERSION).tar.gz
+FPING_SOURCE_SHA256 := be320771f075e47dd7e5704b485e9bdc7dd11107884345c0f7c18749357f668d

--- a/tools/htop/Dockerfile
+++ b/tools/htop/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG HTOP_VERSION
+ARG HTOP_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# xz for the official release tarball. ncurses and libcap come from the prefix.
+RUN apk add --no-cache \
+    build-base=0.5-r3 \
+    linux-headers=6.6-r1 \
+    xz=5.8.3-r0
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://github.com/htop-dev/htop/releases/download/${HTOP_VERSION}/htop-${HTOP_VERSION}.tar.xz" -O htop.tar.xz && \
+    echo "${HTOP_SOURCE_SHA256}  htop.tar.xz" | sha256sum -c -
+
+RUN tar xf htop.tar.xz && \
+    cd htop-${HTOP_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --enable-static \
+        --enable-unicode \
+        --enable-capabilities \
+        --disable-unwind && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    mkdir -p /out && \
+    cp htop /out/htop && \
+    strip /out/htop && \
+    file /out/htop | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/htop/Makefile
+++ b/tools/htop/Makefile
@@ -1,0 +1,71 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/htop
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/htop
+
+$(TOOL_OUT_DIR)/$(ARCH)/htop: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libncursesw.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg HTOP_VERSION=$(HTOP_VERSION) \
+		--build-arg HTOP_SOURCE_SHA256=$(HTOP_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built htop $(HTOP_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libncursesw.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing htop binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/htop || (echo "ERROR: htop binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/htop | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/htop:/htop:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /htop --version 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "htop" || (echo "ERROR: htop --version failed: $$OUTPUT" && exit 1)
+	@echo "✓ htop --version works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/htop:/htop:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /htop --help 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "usage\|htop" || (echo "ERROR: htop --help failed: $$OUTPUT" && exit 1)
+	@echo "✓ htop --help works"
+	@echo "==> All htop tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/htop
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: htop $(HTOP_VERSION)"
+	@echo "URL: $(HTOP_SOURCE_URL)"
+	@echo "SHA256: $(HTOP_SOURCE_SHA256)"

--- a/tools/htop/versions.mk
+++ b/tools/htop/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+HTOP_VERSION := 3.5.3
+HTOP_SOURCE_URL := https://github.com/htop-dev/htop/releases/download/$(HTOP_VERSION)/htop-$(HTOP_VERSION).tar.xz
+HTOP_SOURCE_SHA256 := a8b164386494cb85bb255a415a3f5f80afe7a0c4491da5d113b3a0f951087e65

--- a/tools/jq/Dockerfile
+++ b/tools/jq/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG JQ_VERSION
+ARG JQ_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+RUN apk add --no-cache \
+    build-base=0.5-r3
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.tar.gz" -O jq.tar.gz && \
+    echo "${JQ_SOURCE_SHA256}  jq.tar.gz" | sha256sum -c -
+
+RUN tar xzf jq.tar.gz && \
+    cd jq-${JQ_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --disable-shared \
+        --enable-static \
+        --disable-docs \
+        --disable-maintainer-mode \
+        --with-oniguruma=builtin && \
+    make -j"$(nproc)" \
+        LDFLAGS="-L${PREFIX}/lib -static -all-static" \
+        jq_LDFLAGS="-static -all-static" && \
+    mkdir -p /out && \
+    cp jq /out/jq && \
+    strip /out/jq && \
+    file /out/jq | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/jq/Makefile
+++ b/tools/jq/Makefile
@@ -1,0 +1,72 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/jq
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/jq
+
+$(TOOL_OUT_DIR)/$(ARCH)/jq: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg JQ_VERSION=$(JQ_VERSION) \
+		--build-arg JQ_SOURCE_SHA256=$(JQ_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built jq $(JQ_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing jq binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/jq || (echo "ERROR: jq binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/jq | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/jq:/jq:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /jq --version 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "jq" || (echo "ERROR: jq --version failed: $$OUTPUT" && exit 1)
+	@echo "✓ jq --version works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/jq:/jq:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) \
+		/bin/sh -c 'printf "{\"a\":1}" | /jq -r .a' 2>&1) && \
+		echo "$$OUTPUT" | grep -qx "1" || (echo "ERROR: jq filter failed: $$OUTPUT" && exit 1)
+	@echo "✓ jq filter works"
+	@echo "==> All jq tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/jq
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: jq $(JQ_VERSION)"
+	@echo "URL: $(JQ_SOURCE_URL)"
+	@echo "SHA256: $(JQ_SOURCE_SHA256)"

--- a/tools/jq/versions.mk
+++ b/tools/jq/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+JQ_VERSION := 1.8.2
+JQ_SOURCE_URL := https://github.com/jqlang/jq/releases/download/jq-$(JQ_VERSION)/jq-$(JQ_VERSION).tar.gz
+JQ_SOURCE_SHA256 := 71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af

--- a/tools/ncdu/Dockerfile
+++ b/tools/ncdu/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG NCDU_VERSION
+ARG NCDU_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# Compiler only. ncurses comes from the SHA256-pinned prefix.
+RUN apk add --no-cache \
+    build-base=0.5-r3
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://dev.yorhel.nl/download/ncdu-${NCDU_VERSION}.tar.gz" -O ncdu.tar.gz && \
+    echo "${NCDU_SOURCE_SHA256}  ncdu.tar.gz" | sha256sum -c -
+
+RUN tar xzf ncdu.tar.gz && \
+    cd ncdu-${NCDU_VERSION} && \
+    ./configure --prefix=/usr && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    mkdir -p /out && \
+    cp ncdu /out/ncdu && \
+    strip /out/ncdu && \
+    file /out/ncdu | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/ncdu/Makefile
+++ b/tools/ncdu/Makefile
@@ -1,0 +1,71 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/ncdu
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/ncdu
+
+$(TOOL_OUT_DIR)/$(ARCH)/ncdu: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libncursesw.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg NCDU_VERSION=$(NCDU_VERSION) \
+		--build-arg NCDU_SOURCE_SHA256=$(NCDU_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built ncdu $(NCDU_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libncursesw.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing ncdu binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/ncdu || (echo "ERROR: ncdu binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/ncdu | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/ncdu:/ncdu:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /ncdu -v 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "ncdu" || (echo "ERROR: ncdu -v failed: $$OUTPUT" && exit 1)
+	@echo "✓ ncdu -v works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/ncdu:/ncdu:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /ncdu -h 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "usage\|ncdu" || (echo "ERROR: ncdu -h failed: $$OUTPUT" && exit 1)
+	@echo "✓ ncdu -h works"
+	@echo "==> All ncdu tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/ncdu
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: ncdu $(NCDU_VERSION)"
+	@echo "URL: $(NCDU_SOURCE_URL)"
+	@echo "SHA256: $(NCDU_SOURCE_SHA256)"

--- a/tools/ncdu/versions.mk
+++ b/tools/ncdu/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+NCDU_VERSION := 1.22
+NCDU_SOURCE_URL := https://dev.yorhel.nl/download/ncdu-$(NCDU_VERSION).tar.gz
+NCDU_SOURCE_SHA256 := 0ad6c096dc04d5120581104760c01b8f4e97d4191d6c9ef79654fa3c691a176b

--- a/tools/socat/Dockerfile
+++ b/tools/socat/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG SOCAT_VERSION
+ARG SOCAT_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# Compiler only. OpenSSL comes from the SHA256-pinned prefix.
+RUN apk add --no-cache \
+    build-base=0.5-r3 \
+    linux-headers=6.6-r1
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LIBS="-lssl -lcrypto -lz -ldl -lpthread"
+
+WORKDIR /src
+RUN wget -q "http://www.dest-unreach.org/socat/download/socat-${SOCAT_VERSION}.tar.gz" -O socat.tar.gz && \
+    echo "${SOCAT_SOURCE_SHA256}  socat.tar.gz" | sha256sum -c -
+
+RUN tar xzf socat.tar.gz && \
+    cd socat-${SOCAT_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --disable-readline \
+        --disable-libwrap \
+        --enable-openssl && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    mkdir -p /out && \
+    cp socat /out/socat && \
+    strip /out/socat && \
+    file /out/socat | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/socat/Makefile
+++ b/tools/socat/Makefile
@@ -1,0 +1,71 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/socat
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/socat
+
+$(TOOL_OUT_DIR)/$(ARCH)/socat: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg SOCAT_VERSION=$(SOCAT_VERSION) \
+		--build-arg SOCAT_SOURCE_SHA256=$(SOCAT_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built socat $(SOCAT_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing socat binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/socat || (echo "ERROR: socat binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/socat | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/socat:/socat:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /socat -V 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "socat" || (echo "ERROR: socat -V failed: $$OUTPUT" && exit 1)
+	@echo "✓ socat -V works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/socat:/socat:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /socat -V 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "openssl" || (echo "ERROR: socat missing OpenSSL: $$OUTPUT" && exit 1)
+	@echo "✓ socat is built with OpenSSL"
+	@echo "==> All socat tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/socat
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: socat $(SOCAT_VERSION)"
+	@echo "URL: $(SOCAT_SOURCE_URL)"
+	@echo "SHA256: $(SOCAT_SOURCE_SHA256)"

--- a/tools/socat/versions.mk
+++ b/tools/socat/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+SOCAT_VERSION := 1.8.1.3
+SOCAT_SOURCE_URL := http://www.dest-unreach.org/socat/download/socat-$(SOCAT_VERSION).tar.gz
+SOCAT_SOURCE_SHA256 := 06602ffd591e98c75b3dc1d66f0f19136cc666b0b2d95caad987d6ab2cb28097

--- a/tools/strace/Dockerfile
+++ b/tools/strace/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG STRACE_VERSION
+ARG STRACE_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+# xz for the official release tarball. --enable-mpers=no is required for musl static.
+RUN apk add --no-cache \
+    build-base=0.5-r3 \
+    linux-headers=6.6-r1 \
+    xz=5.8.3-r0
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib -static" \
+    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+
+WORKDIR /src
+RUN wget -q "https://github.com/strace/strace/releases/download/v${STRACE_VERSION}/strace-${STRACE_VERSION}.tar.xz" -O strace.tar.xz && \
+    echo "${STRACE_SOURCE_SHA256}  strace.tar.xz" | sha256sum -c -
+
+RUN tar xf strace.tar.xz && \
+    cd strace-${STRACE_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --enable-mpers=no && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    mkdir -p /out && \
+    cp src/strace /out/strace && \
+    strip /out/strace && \
+    file /out/strace | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/strace/Makefile
+++ b/tools/strace/Makefile
@@ -1,0 +1,70 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/strace
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/strace
+
+$(TOOL_OUT_DIR)/$(ARCH)/strace: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg STRACE_VERSION=$(STRACE_VERSION) \
+		--build-arg STRACE_SOURCE_SHA256=$(STRACE_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built strace $(STRACE_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing strace binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/strace || (echo "ERROR: strace binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/strace | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/strace:/strace:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /strace -V 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "strace" || (echo "ERROR: strace -V failed: $$OUTPUT" && exit 1)
+	@echo "✓ strace -V works"
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/strace:/strace:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /strace -e trace=none /bin/true 2>&1) && \
+		echo "✓ strace /bin/true works" || (echo "ERROR: strace /bin/true failed: $$OUTPUT" && exit 1)
+	@echo "==> All strace tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/strace
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: strace $(STRACE_VERSION)"
+	@echo "URL: $(STRACE_SOURCE_URL)"
+	@echo "SHA256: $(STRACE_SOURCE_SHA256)"

--- a/tools/strace/versions.mk
+++ b/tools/strace/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+STRACE_VERSION := 6.17
+STRACE_SOURCE_URL := https://github.com/strace/strace/releases/download/v$(STRACE_VERSION)/strace-$(STRACE_VERSION).tar.xz
+STRACE_SOURCE_SHA256 := 0a7c7bedc7efc076f3242a0310af2ae63c292a36dd4236f079e88a93e98cb9c0

--- a/tools/xxd/Dockerfile
+++ b/tools/xxd/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+
+ARG ALPINE_VERSION=3.21
+ARG ALPINE_DIGEST
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
+
+ARG XXD_VERSION
+ARG XXD_SOURCE_SHA256
+ARG TARGETARCH
+ARG PREFIX=/opt/st
+
+RUN apk add --no-cache \
+    build-base=0.5-r3
+
+COPY --from=deps / ${PREFIX}
+
+ENV PATH="${PREFIX}/bin:${PATH}" \
+    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static"
+
+WORKDIR /src
+RUN wget -q "https://github.com/xyproto/tinyxxd/archive/refs/tags/v${XXD_VERSION}.tar.gz" -O tinyxxd.tar.gz && \
+    echo "${XXD_SOURCE_SHA256}  tinyxxd.tar.gz" | sha256sum -c -
+
+RUN tar xzf tinyxxd.tar.gz && \
+    cd tinyxxd-${XXD_VERSION} && \
+    make -j"$(nproc)" && \
+    mkdir -p /out && \
+    cp tinyxxd /out/xxd && \
+    strip /out/xxd && \
+    file /out/xxd | grep -q "statically linked" && \
+    cd /out && sha256sum * > SHA256SUMS
+
+FROM scratch AS export
+COPY --from=builder /out/ /

--- a/tools/xxd/Makefile
+++ b/tools/xxd/Makefile
@@ -1,0 +1,67 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail -c
+
+include versions.mk
+
+ARCH ?= amd64
+ARCHS := amd64 arm64
+DOCKER ?= docker
+BUILDX ?= $(DOCKER) buildx
+OUT_DIR ?= $(CURDIR)/../../dist
+TOOL_OUT_DIR := $(OUT_DIR)/xxd
+DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
+PLATFORM_amd64 := linux/amd64
+PLATFORM_arm64 := linux/arm64
+ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
+ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
+
+.PHONY: deps build build-all test verify-static clean info
+
+deps:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build: $(TOOL_OUT_DIR)/$(ARCH)/xxd
+
+$(TOOL_OUT_DIR)/$(ARCH)/xxd: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
+	$(BUILDX) build \
+		--platform $(PLATFORM_$(ARCH)) \
+		--build-context deps=$(DEPS_PREFIX) \
+		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
+		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
+		--build-arg XXD_VERSION=$(XXD_VERSION) \
+		--build-arg XXD_SOURCE_SHA256=$(XXD_SOURCE_SHA256) \
+		--output type=local,dest=$(TOOL_OUT_DIR)/$(ARCH) \
+		--target export \
+		.
+	@echo "Built xxd $(XXD_VERSION) for $(ARCH):"
+	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
+
+$(DEPS_PREFIX)/lib/libssl.a:
+	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+
+build-all:
+	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
+
+test: build
+	@echo "==> Testing xxd binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/xxd || (echo "ERROR: xxd binary not found" && exit 1)
+	@file $(TOOL_OUT_DIR)/$(ARCH)/xxd | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/xxd:/xxd:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) \
+		/bin/sh -c 'printf ABC | /xxd' 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "4142" || (echo "ERROR: xxd encode failed: $$OUTPUT" && exit 1)
+	@echo "✓ xxd encodes hex"
+	@echo "==> All xxd tests passed"
+
+verify-static: build
+	@file $(TOOL_OUT_DIR)/$(ARCH)/xxd
+
+clean:
+	rm -rf $(TOOL_OUT_DIR)
+
+info:
+	@echo "Tool: xxd (tinyxxd $(XXD_VERSION))"
+	@echo "URL: $(XXD_SOURCE_URL)"
+	@echo "SHA256: $(XXD_SOURCE_SHA256)"

--- a/tools/xxd/versions.mk
+++ b/tools/xxd/versions.mk
@@ -1,0 +1,5 @@
+include ../../deps/versions.mk
+
+XXD_VERSION := 1.3.16
+XXD_SOURCE_URL := https://github.com/xyproto/tinyxxd/archive/refs/tags/v$(XXD_VERSION).tar.gz
+XXD_SOURCE_SHA256 := f74a3cbcdd3166f0f966f97ad483a60a34b53a09abd9ba63783c0958640ca9d9


### PR DESCRIPTION
## Summary
- Add statically linked musl builds for socat, jq, fping, strace, ncdu, file, xxd (tinyxxd), and htop.
- Wire the new tools into the root `TOOLS` list, CI/release matrices, and README catalog.
- Publish `file` with its `magic.mgc` database, matching the existing mtr multi-artifact release path.

## Test plan
- [x] `make test-socat test-jq test-fping test-strace test-ncdu test-file test-xxd test-htop` on amd64
- [x] `make lint`
- [x] CI matrix builds amd64 and arm64 for each new tool
- [x] Confirm `file-<arch>` and `magic.mgc-<arch>` both land on a release