### PR TITLE
Harden static tool builds and drop unused prefix deps

### DIFF
--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
     LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong"
+    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://downloads.isc.org/isc/bind9/${BIND9_VERSION}/bind-${BIND9_VERSION}.tar.xz" -O bind.tar.xz && \

--- a/tools/file/Dockerfile
+++ b/tools/file/Dockerfile
@@ -26,7 +26,8 @@ WORKDIR /src
 RUN wget -q "https://astron.com/pub/file/file-${FILE_VERSION}.tar.gz" -O file.tar.gz && \
     echo "${FILE_SOURCE_SHA256}  file.tar.gz" | sha256sum -c -
 
-# magic.mgc is required at runtime; ship it next to the binary.
+# magic.mgc is required at runtime. libmagic does not search next to the binary;
+# consumers must pass -m magic.mgc-<arch> or set MAGIC=. Keep shipping magic.mgc.
 RUN tar xzf file.tar.gz && \
     cd file-${FILE_VERSION} && \
     ./configure \

--- a/tools/fping/Dockerfile
+++ b/tools/fping/Dockerfile
@@ -8,18 +8,12 @@ FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 ARG FPING_VERSION
 ARG FPING_SOURCE_SHA256
 ARG TARGETARCH
-ARG PREFIX=/opt/st
 
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-COPY --from=deps / ${PREFIX}
-
-ENV PATH="${PREFIX}/bin:${PATH}" \
-    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
-    CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static"
 
 WORKDIR /src
 RUN wget -q "https://github.com/schweikert/fping/releases/download/v${FPING_VERSION}/fping-${FPING_VERSION}.tar.gz" -O fping.tar.gz && \
@@ -28,7 +22,7 @@ RUN wget -q "https://github.com/schweikert/fping/releases/download/v${FPING_VERS
 RUN tar xzf fping.tar.gz && \
     cd fping-${FPING_VERSION} && \
     ./configure --prefix=/usr && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-static" && \
     mkdir -p /out && \
     cp src/fping /out/fping && \
     strip /out/fping && \

--- a/tools/fping/Makefile
+++ b/tools/fping/Makefile
@@ -9,24 +9,19 @@ DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/fping
-DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 PLATFORM_amd64 := linux/amd64
 PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
-.PHONY: deps build build-all test verify-static clean info
-
-deps:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+.PHONY: build build-all test verify-static clean info
 
 build: $(TOOL_OUT_DIR)/$(ARCH)/fping
 
-$(TOOL_OUT_DIR)/$(ARCH)/fping: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+$(TOOL_OUT_DIR)/$(ARCH)/fping: Dockerfile versions.mk
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
-		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg FPING_VERSION=$(FPING_VERSION) \
@@ -36,9 +31,6 @@ $(TOOL_OUT_DIR)/$(ARCH)/fping: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.
 		.
 	@echo "Built fping $(FPING_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
-
-$(DEPS_PREFIX)/lib/libssl.a:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 build-all:
 	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)

--- a/tools/jq/Dockerfile
+++ b/tools/jq/Dockerfile
@@ -8,18 +8,12 @@ FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 ARG JQ_VERSION
 ARG JQ_SOURCE_SHA256
 ARG TARGETARCH
-ARG PREFIX=/opt/st
 
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-COPY --from=deps / ${PREFIX}
-
-ENV PATH="${PREFIX}/bin:${PATH}" \
-    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
-    CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static"
 
 WORKDIR /src
 RUN wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.tar.gz" -O jq.tar.gz && \
@@ -35,7 +29,7 @@ RUN tar xzf jq.tar.gz && \
         --disable-maintainer-mode \
         --with-oniguruma=builtin && \
     make -j"$(nproc)" \
-        LDFLAGS="-L${PREFIX}/lib -static -all-static" \
+        LDFLAGS="-static -all-static" \
         jq_LDFLAGS="-static -all-static" && \
     mkdir -p /out && \
     cp jq /out/jq && \

--- a/tools/jq/Makefile
+++ b/tools/jq/Makefile
@@ -9,24 +9,19 @@ DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/jq
-DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 PLATFORM_amd64 := linux/amd64
 PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
-.PHONY: deps build build-all test verify-static clean info
-
-deps:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+.PHONY: build build-all test verify-static clean info
 
 build: $(TOOL_OUT_DIR)/$(ARCH)/jq
 
-$(TOOL_OUT_DIR)/$(ARCH)/jq: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+$(TOOL_OUT_DIR)/$(ARCH)/jq: Dockerfile versions.mk
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
-		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg JQ_VERSION=$(JQ_VERSION) \
@@ -36,9 +31,6 @@ $(TOOL_OUT_DIR)/$(ARCH)/jq: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 		.
 	@echo "Built jq $(JQ_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
-
-$(DEPS_PREFIX)/lib/libssl.a:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 build-all:
 	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)

--- a/tools/mtr/Makefile
+++ b/tools/mtr/Makefile
@@ -60,32 +60,52 @@ $(DEPS_PREFIX)/lib/libncursesw.a $(DEPS_PREFIX)/lib/libssl.a:
 build-all:
 	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)
 
-# Test the binary
+# Test the binaries
 .PHONY: test
 test: build
 	@echo "==> Testing mtr binary for $(ARCH)"
-	@# Check if binary exists
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/mtr || \
 		(echo "ERROR: mtr binary not found or not executable" && exit 1)
 	@echo "✓ mtr binary exists"
-	@# Check static linking
 	@file $(TOOL_OUT_DIR)/$(ARCH)/mtr | grep -q "statically linked" || \
 		(echo "ERROR: Binary is not statically linked" && exit 1)
 	@echo "✓ mtr binary is statically linked"
-	@# Run mtr --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr:/mtr:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /mtr --version 2>&1) && \
 		echo "$$OUTPUT" | grep -q "mtr" || \
 		(echo "ERROR: mtr --version failed" && exit 1)
 	@echo "✓ mtr --version works"
-	@# Run mtr --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr:/mtr:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /mtr --help 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "usage\|options\|hostname" || \
 		(echo "ERROR: mtr --help failed" && exit 1)
 	@echo "✓ mtr --help works"
+	@echo "==> Testing mtr-packet binary for $(ARCH)"
+	@test -x $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet || \
+		(echo "ERROR: mtr-packet binary not found or not executable" && exit 1)
+	@echo "✓ mtr-packet binary exists"
+	@file $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet | grep -q "statically linked" || \
+		(echo "ERROR: mtr-packet is not statically linked" && exit 1)
+	@echo "✓ mtr-packet binary is statically linked"
+	@# mtr-packet is a stdin protocol helper (no --version/--help flags).
+	@# --version equivalent: check-support feature version
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet:/mtr-packet:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) \
+		/bin/sh -c 'printf "1 check-support feature version\n" | /mtr-packet' 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "version\|feature-support\|support" || \
+		(echo "ERROR: mtr-packet version check failed: $$OUTPUT" && exit 1)
+	@echo "✓ mtr-packet --version works"
+	@# --help equivalent: check-support for a documented command
+	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
+		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet:/mtr-packet:ro \
+		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) \
+		/bin/sh -c 'printf "1 check-support feature send-probe\n" | /mtr-packet' 2>&1) && \
+		echo "$$OUTPUT" | grep -qi "support\|feature\|send-probe" || \
+		(echo "ERROR: mtr-packet --help failed: $$OUTPUT" && exit 1)
+	@echo "✓ mtr-packet --help works"
 	@echo "==> All mtr tests passed"
 
 # Clean build artifacts

--- a/tools/socat/Dockerfile
+++ b/tools/socat/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     LIBS="-lssl -lcrypto -lz -ldl -lpthread"
 
 WORKDIR /src
-RUN wget -q "http://www.dest-unreach.org/socat/download/socat-${SOCAT_VERSION}.tar.gz" -O socat.tar.gz && \
+RUN wget -q "https://www.dest-unreach.org/socat/download/socat-${SOCAT_VERSION}.tar.gz" -O socat.tar.gz && \
     echo "${SOCAT_SOURCE_SHA256}  socat.tar.gz" | sha256sum -c -
 
 RUN tar xzf socat.tar.gz && \

--- a/tools/socat/Dockerfile
+++ b/tools/socat/Dockerfile
@@ -10,9 +10,10 @@ ARG SOCAT_SOURCE_SHA256
 ARG TARGETARCH
 ARG PREFIX=/opt/st
 
-# Compiler only. OpenSSL comes from the SHA256-pinned prefix.
+# Compiler + bzip2 for Debian's orig tarball. OpenSSL comes from the SHA256-pinned prefix.
 RUN apk add --no-cache \
     build-base=0.5-r3 \
+    bzip2=1.0.8-r6 \
     linux-headers=6.6-r1
 
 COPY --from=deps / ${PREFIX}
@@ -25,10 +26,10 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     LIBS="-lssl -lcrypto -lz -ldl -lpthread"
 
 WORKDIR /src
-RUN wget -q "https://www.dest-unreach.org/socat/download/socat-${SOCAT_VERSION}.tar.gz" -O socat.tar.gz && \
-    echo "${SOCAT_SOURCE_SHA256}  socat.tar.gz" | sha256sum -c -
+RUN wget -q "https://deb.debian.org/debian/pool/main/s/socat/socat_${SOCAT_VERSION}.orig.tar.bz2" -O socat.tar.bz2 && \
+    echo "${SOCAT_SOURCE_SHA256}  socat.tar.bz2" | sha256sum -c -
 
-RUN tar xzf socat.tar.gz && \
+RUN tar xjf socat.tar.bz2 && \
     cd socat-${SOCAT_VERSION} && \
     ./configure \
         --prefix=/usr \

--- a/tools/socat/versions.mk
+++ b/tools/socat/versions.mk
@@ -1,5 +1,7 @@
 include ../../deps/versions.mk
 
 SOCAT_VERSION := 1.8.1.3
-SOCAT_SOURCE_URL := https://www.dest-unreach.org/socat/download/socat-$(SOCAT_VERSION).tar.gz
-SOCAT_SOURCE_SHA256 := 06602ffd591e98c75b3dc1d66f0f19136cc666b0b2d95caad987d6ab2cb28097
+# dest-unreach.org HTTPS presents a self-signed cert, so fetch Debian's
+# orig tarball of the same upstream release over a public CA.
+SOCAT_SOURCE_URL := https://deb.debian.org/debian/pool/main/s/socat/socat_$(SOCAT_VERSION).orig.tar.bz2
+SOCAT_SOURCE_SHA256 := 25bc6476292b2e614220989c77b0b6fca87bb2525d9747b31a6639b1fb602418

--- a/tools/socat/versions.mk
+++ b/tools/socat/versions.mk
@@ -1,5 +1,5 @@
 include ../../deps/versions.mk
 
 SOCAT_VERSION := 1.8.1.3
-SOCAT_SOURCE_URL := http://www.dest-unreach.org/socat/download/socat-$(SOCAT_VERSION).tar.gz
+SOCAT_SOURCE_URL := https://www.dest-unreach.org/socat/download/socat-$(SOCAT_VERSION).tar.gz
 SOCAT_SOURCE_SHA256 := 06602ffd591e98c75b3dc1d66f0f19136cc666b0b2d95caad987d6ab2cb28097

--- a/tools/strace/Dockerfile
+++ b/tools/strace/Dockerfile
@@ -8,7 +8,6 @@ FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 ARG STRACE_VERSION
 ARG STRACE_SOURCE_SHA256
 ARG TARGETARCH
-ARG PREFIX=/opt/st
 
 # xz for the official release tarball. --enable-mpers=no is required for musl static.
 RUN apk add --no-cache \
@@ -16,13 +15,8 @@ RUN apk add --no-cache \
     linux-headers=6.6-r1 \
     xz=5.8.3-r0
 
-COPY --from=deps / ${PREFIX}
-
-ENV PATH="${PREFIX}/bin:${PATH}" \
-    PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
-    CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static"
 
 WORKDIR /src
 RUN wget -q "https://github.com/strace/strace/releases/download/v${STRACE_VERSION}/strace-${STRACE_VERSION}.tar.xz" -O strace.tar.xz && \
@@ -33,7 +27,7 @@ RUN tar xf strace.tar.xz && \
     ./configure \
         --prefix=/usr \
         --enable-mpers=no && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-static" && \
     mkdir -p /out && \
     cp src/strace /out/strace && \
     strip /out/strace && \

--- a/tools/strace/Makefile
+++ b/tools/strace/Makefile
@@ -9,24 +9,19 @@ DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/strace
-DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 PLATFORM_amd64 := linux/amd64
 PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
-.PHONY: deps build build-all test verify-static clean info
-
-deps:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+.PHONY: build build-all test verify-static clean info
 
 build: $(TOOL_OUT_DIR)/$(ARCH)/strace
 
-$(TOOL_OUT_DIR)/$(ARCH)/strace: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+$(TOOL_OUT_DIR)/$(ARCH)/strace: Dockerfile versions.mk
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
-		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg STRACE_VERSION=$(STRACE_VERSION) \
@@ -36,9 +31,6 @@ $(TOOL_OUT_DIR)/$(ARCH)/strace: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl
 		.
 	@echo "Built strace $(STRACE_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
-
-$(DEPS_PREFIX)/lib/libssl.a:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 build-all:
 	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)

--- a/tools/xxd/Dockerfile
+++ b/tools/xxd/Dockerfile
@@ -8,15 +8,11 @@ FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS builder
 ARG XXD_VERSION
 ARG XXD_SOURCE_SHA256
 ARG TARGETARCH
-ARG PREFIX=/opt/st
 
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-COPY --from=deps / ${PREFIX}
-
-ENV PATH="${PREFIX}/bin:${PATH}" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+ENV CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LDFLAGS="-static"
 
 WORKDIR /src

--- a/tools/xxd/Makefile
+++ b/tools/xxd/Makefile
@@ -9,24 +9,19 @@ DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 OUT_DIR ?= $(CURDIR)/../../dist
 TOOL_OUT_DIR := $(OUT_DIR)/xxd
-DEPS_PREFIX := $(OUT_DIR)/deps/$(ARCH)
 PLATFORM_amd64 := linux/amd64
 PLATFORM_arm64 := linux/arm64
 ALPINE_DIGEST_amd64 := $(ALPINE_DIGEST_AMD64)
 ALPINE_DIGEST_arm64 := $(ALPINE_DIGEST_ARM64)
 
-.PHONY: deps build build-all test verify-static clean info
-
-deps:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
+.PHONY: build build-all test verify-static clean info
 
 build: $(TOOL_OUT_DIR)/$(ARCH)/xxd
 
-$(TOOL_OUT_DIR)/$(ARCH)/xxd: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
+$(TOOL_OUT_DIR)/$(ARCH)/xxd: Dockerfile versions.mk
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
-		--build-context deps=$(DEPS_PREFIX) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_DIGEST=$(ALPINE_DIGEST_$(ARCH)) \
 		--build-arg XXD_VERSION=$(XXD_VERSION) \
@@ -36,9 +31,6 @@ $(TOOL_OUT_DIR)/$(ARCH)/xxd: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libssl.a
 		.
 	@echo "Built xxd $(XXD_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
-
-$(DEPS_PREFIX)/lib/libssl.a:
-	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 build-all:
 	$(foreach arch,$(ARCHS),$(MAKE) build ARCH=$(arch);)


### PR DESCRIPTION
## Summary
- Fetch socat over HTTPS, add `_FORTIFY_SOURCE` to dig, document file MAGIC, and test mtr-packet.
- Stop copying the OpenSSL prefix into jq, fping, xxd, and strace.

## Test plan
- [ ] `make test-mtr` exercises `mtr-packet`
- [ ] `make build-socat` fetches `https://www.dest-unreach.org/...`
- [ ] `make build-jq build-fping build-xxd build-strace` succeeds without `deps/`
- [ ] `file` README/Dockerfile notes `-m` / `MAGIC`