### PR TITLE
Honor ARCH in Make and harden CI lint and signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 jobs:
-  # Verify all commits are signed
+  # Verify commits in the push/PR range are signed
   verify-signatures:
     name: Verify commit signatures
     runs-on: ubuntu-24.04
@@ -28,16 +28,54 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check all commits are signed
+      - name: Check commit signatures in range
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "Checking commit signatures..."
-          UNSIGNED_COMMITS=$(git log --format="%H %G? %s" | grep " N " || true)
-          if [ -n "$UNSIGNED_COMMITS" ]; then
-            echo "::error::Found unsigned commits:"
-            echo "$UNSIGNED_COMMITS"
+          set -euo pipefail
+          echo "Importing GitHub web-flow signing key..."
+          curl -fsSL https://github.com/web-flow.gpg | gpg --import
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            RANGE="${PR_BASE}..${PR_HEAD}"
+          elif [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
+            if git rev-parse --verify --quiet origin/main; then
+              RANGE="origin/main..${SHA}"
+            else
+              RANGE="${SHA}^!"
+            fi
+          else
+            RANGE="${BEFORE}..${SHA}"
+          fi
+
+          echo "Checking commit signatures in ${RANGE}..."
+          failed=0
+          while IFS=$'\t' read -r hash status; do
+            [ -z "${hash}" ] && continue
+            case "${status}" in
+              N)
+                echo "::error::Unsigned commit: ${hash}"
+                failed=1
+                ;;
+              B)
+                echo "::error::Bad signature: ${hash}"
+                failed=1
+                ;;
+              E)
+                echo "::error::Cannot check signature (missing key): ${hash}"
+                failed=1
+                ;;
+            esac
+          done < <(git log --format="%H%x09%G?" "${RANGE}")
+
+          if [ "${failed}" -ne 0 ]; then
             exit 1
           fi
-          echo "✓ All commits are signed"
+          echo "✓ Commit signatures verified for ${RANGE}"
 
   changes:
     name: Detect changed tools
@@ -191,7 +229,11 @@ jobs:
 
       - name: Install hadolint
         run: |
+          set -euo pipefail
+          # v2.12.0 Linux x86_64 SHA256 from https://github.com/hadolint/hadolint/releases/tag/v2.12.0
+          HADOLINT_SHA256="56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010"
           wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+          echo "${HADOLINT_SHA256}  /usr/local/bin/hadolint" | sha256sum -c -
           chmod +x /usr/local/bin/hadolint
 
       - name: Lint Dockerfiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
           SHA: ${{ github.sha }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          echo "Importing GitHub web-flow signing key..."
+          echo "Importing GitHub web-flow and ${OWNER} signing keys..."
           curl -fsSL https://github.com/web-flow.gpg | gpg --import
+          curl -fsSL "https://github.com/${OWNER}.gpg" | gpg --import
 
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             RANGE="${PR_BASE}..${PR_HEAD}"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else
     $(error Unsupported architecture: $(UNAME_M))
 endif
 
+# Architecture for build-% / test-% (CI sets ARCH=; local defaults to host)
+ARCH ?= $(HOST_ARCH)
+
 # Docker configuration
 DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
@@ -68,8 +71,8 @@ build: $(addprefix build-,$(TOOLS))
 # Build specific tool for host architecture
 .PHONY: build-%
 build-%:
-	@echo "==> Building $* for $(HOST_ARCH)"
-	$(MAKE) -C tools/$* build ARCH=$(HOST_ARCH) OUT_DIR=$(OUT_DIR)
+	@echo "==> Building $* for $(ARCH)"
+	$(MAKE) -C tools/$* build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build all tools for all architectures (CI)
 .PHONY: build-all
@@ -87,20 +90,30 @@ test: $(addprefix test-,$(TOOLS))
 .PHONY: test-%
 test-%:
 	@echo "==> Testing $*"
-	$(MAKE) -C tools/$* test ARCH=$(HOST_ARCH)
+	$(MAKE) -C tools/$* test ARCH=$(ARCH)
+
+# Pinned hadolint v2.12.0 (SHA256 from GitHub release checksum files)
+HADOLINT_VERSION := 2.12.0
+HADOLINT_SHA256_amd64 := 56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010
+HADOLINT_SHA256_arm64 := 5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6
 
 # Lint Dockerfiles and scripts
 .PHONY: lint
 lint:
 	@echo "==> Linting Dockerfiles"
-	@HADOLINT=$$(command -v hadolint 2>/dev/null || echo ""); \
-	if [ -z "$$HADOLINT" ] || [ ! -x "$$HADOLINT" ]; then \
-		echo "Installing hadolint..."; \
-		if [ "$(HOST_ARCH)" = "amd64" ]; then \
-			wget -qO /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64; \
-		else \
-			wget -qO /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-arm64; \
-		fi; \
+	@HADOLINT_SHA256="$(HADOLINT_SHA256_$(HOST_ARCH))"; \
+	if [ "$(HOST_ARCH)" = "amd64" ]; then \
+		HADOLINT_ASSET="hadolint-Linux-x86_64"; \
+	else \
+		HADOLINT_ASSET="hadolint-Linux-arm64"; \
+	fi; \
+	HADOLINT=$$(command -v hadolint 2>/dev/null || echo ""); \
+	if [ -n "$$HADOLINT" ] && [ -x "$$HADOLINT" ] && echo "$$HADOLINT_SHA256  $$HADOLINT" | sha256sum -c - >/dev/null 2>&1; then \
+		true; \
+	else \
+		echo "Installing hadolint v$(HADOLINT_VERSION)..."; \
+		wget -qO /tmp/hadolint "https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/$$HADOLINT_ASSET"; \
+		echo "$$HADOLINT_SHA256  /tmp/hadolint" | sha256sum -c -; \
 		chmod +x /tmp/hadolint; \
 		HADOLINT=/tmp/hadolint; \
 	fi; \


### PR DESCRIPTION
## Summary
- Pass `ARCH=` through root `build-%` / `test-%` instead of always using `HOST_ARCH`.
- Pin hadolint v2.12.0 by SHA256.
- Verify only the push/PR commit range after importing GitHub's web-flow key and the repository owner's GPG keys.

## Test plan
- [x] CI lint job installs hadolint and checksums it
- [x] Signature job accepts maintainer-signed commits and GitHub-signed squash merges
- [x] `make build-curl ARCH=amd64` uses the requested arch