### PR TITLE
Isolate release provenance signing for SLSA Build L3

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -1,0 +1,47 @@
+# Isolated provenance signing (SLSA Build L3).
+# workflow_call only so the build job cannot mint attestations.
+name: Attest
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  attest:
+    name: Attest release binaries
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: artifacts
+          merge-multiple: false
+
+      - name: Collect binaries
+        run: |
+          set -euo pipefail
+          mkdir -p subjects
+          find artifacts -type f \( -name '*-amd64' -o -name '*-arm64' \) ! -path 'artifacts/deps-prefix-*/*' -exec cp {} subjects/ \;
+          mapfile -t bins < <(find subjects -maxdepth 1 -type f -printf '%f\n' | sort)
+          binary_count=${#bins[@]}
+          # 2 architectures × (18 tools + mtr-packet + magic.mgc)
+          expected=40
+          echo "Binaries to attest (${binary_count}):"
+          printf '  %s\n' "${bins[@]}"
+          if [ "${binary_count}" -ne "${expected}" ]; then
+            echo "::error::Expected ${expected} binaries to attest, found ${binary_count}"
+            exit 1
+          fi
+
+      - name: Generate build provenance attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            subjects/*-amd64
+            subjects/*-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,5 @@
 # Release workflow for static-tools
-# Builds statically compiled binaries with build provenance attestations
-#
-# This workflow:
-# 1. Builds binaries for each tool/architecture combination
-# 2. Generates build provenance attestations using GitHub Attestations
-# 3. Creates a GitHub release with artifacts
+# Builds statically compiled binaries; provenance is signed in attest.yml
 
 name: Release
 
@@ -21,17 +16,56 @@ on:
 
 permissions: {}
 
-env:
-  # Pinned versions for reproducibility
-  ALPINE_VERSION: "3.21"
-  ALPINE_DIGEST_AMD64: "sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3"
-  ALPINE_DIGEST_ARM64: "sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a"
-
 jobs:
+  verify-tag:
+    name: Verify release tag
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.verify.outputs.tag }}
+    steps:
+      - name: Checkout refs/tags/<tag>
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Verify tag points at the commit being built
+        id: verify
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+            TAG="${TAG#refs/tags/}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          if [[ -z "${TAG}" ]]; then
+            echo "::error::Release tag is empty"
+            exit 1
+          fi
+          if ! git rev-parse --verify --quiet "refs/tags/${TAG}"; then
+            echo "::error::Tag ${TAG} is missing"
+            exit 1
+          fi
+          TAG_SHA="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "${TAG_SHA}" != "${HEAD_SHA}" ]]; then
+            echo "::error::Tag ${TAG} points at ${TAG_SHA} but HEAD is ${HEAD_SHA}"
+            exit 1
+          fi
+          if [[ "${TAG_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::Tag ${TAG} points at ${TAG_SHA} but this workflow run is ${GITHUB_SHA}. Dispatch from the tag so provenance matches the commit being built."
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "Verified tag ${TAG} at ${TAG_SHA}"
+
   # Shared static prefix, built once per architecture in this run.
   # Do not restore a cross-run cache here; release provenance stays hermetic.
   deps:
     name: Deps ${{ matrix.arch }}
+    needs: [verify-tag]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -47,6 +81,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/tags/{0}', needs.verify-tag.outputs.tag) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -63,15 +99,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Build job - runs on native runners for each architecture
   build:
     name: Build ${{ matrix.tool }}-${{ matrix.arch }}
-    needs: [deps]
+    needs: [verify-tag, deps]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -88,6 +121,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/tags/{0}', needs.verify-tag.outputs.tag) }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -113,7 +148,11 @@ jobs:
       - name: Verify binary is statically linked
         run: |
           file dist/${{ matrix.tool }}/${{ matrix.arch }}/${{ matrix.tool }} | grep -q "statically linked"
-          echo "✓ Binary is statically linked"
+          echo "✓ ${{ matrix.tool }} is statically linked"
+          if [ "${{ matrix.tool }}" = "mtr" ]; then
+            file dist/mtr/${{ matrix.arch }}/mtr-packet | grep -q "statically linked"
+            echo "✓ mtr-packet is statically linked"
+          fi
 
       - name: Rename artifacts with architecture suffix
         run: |
@@ -122,43 +161,43 @@ jobs:
             for file in mtr mtr-packet; do
               mv "$file" "$file-${{ matrix.arch }}"
             done
-            sha256sum mtr-${{ matrix.arch }} mtr-packet-${{ matrix.arch }} > SHA256SUMS-${{ matrix.arch }}.txt
           elif [ "${{ matrix.tool }}" = "file" ]; then
             mv file "file-${{ matrix.arch }}"
             mv magic.mgc "magic.mgc-${{ matrix.arch }}"
-            sha256sum "file-${{ matrix.arch }}" "magic.mgc-${{ matrix.arch }}" > SHA256SUMS-${{ matrix.arch }}.txt
           else
             mv ${{ matrix.tool }} ${{ matrix.tool }}-${{ matrix.arch }}
-            sha256sum ${{ matrix.tool }}-${{ matrix.arch }} > SHA256SUMS-${{ matrix.arch }}.txt
           fi
-
-      - name: Generate build provenance attestation
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            dist/${{ matrix.tool }}/${{ matrix.arch }}/*-${{ matrix.arch }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.tool }}-${{ matrix.arch }}
-          path: |
-            dist/${{ matrix.tool }}/${{ matrix.arch }}/*-${{ matrix.arch }}
-            dist/${{ matrix.tool }}/${{ matrix.arch }}/SHA256SUMS-${{ matrix.arch }}.txt
+          path: dist/${{ matrix.tool }}/${{ matrix.arch }}/*-${{ matrix.arch }}
           if-no-files-found: error
           retention-days: 5
 
-  # Create GitHub release with all artifacts
+  attest:
+    needs: [build]
+    uses: ./.github/workflows/attest.yml
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+
   release:
     name: Create GitHub Release
-    needs: [build]
+    needs: [verify-tag, attest]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/tags/{0}', needs.verify-tag.outputs.tag) }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -168,28 +207,34 @@ jobs:
 
       - name: Prepare release assets
         run: |
+          set -euo pipefail
           mkdir -p release
-          # Artifacts are named <tool>-<arch> (and SHA256SUMS-<arch>.txt)
-          find artifacts -type f \( -name "*-amd64" -o -name "*-arm64" -o -name "SHA256SUMS-*.txt" \) ! -path 'artifacts/deps-prefix-*/*' -exec cp {} release/ \;
+          find artifacts -type f \( -name '*-amd64' -o -name '*-arm64' \) ! -path 'artifacts/deps-prefix-*/*' -exec cp {} release/ \;
           cd release
-          cat SHA256SUMS-*.txt > SHA256SUMS.txt
-          ls -la
-
-      - name: Determine release tag
-        id: tag
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          mapfile -t bins < <(find . -maxdepth 1 -type f -printf '%f\n' | sort)
+          binary_count=${#bins[@]}
+          # 2 architectures × (18 tools + mtr-packet + magic.mgc)
+          expected=40
+          echo "Release binaries (${binary_count}):"
+          printf '  %s\n' "${bins[@]}"
+          if [ "${binary_count}" -ne "${expected}" ]; then
+            echo "::error::Expected ${expected} binaries, found ${binary_count}"
+            exit 1
           fi
+          sha256sum "${bins[@]}" > SHA256SUMS.txt
+          sum_count="$(wc -l < SHA256SUMS.txt)"
+          if [ "${sum_count}" -ne "${binary_count}" ]; then
+            echo "::error::SHA256SUMS.txt has ${sum_count} lines, expected ${binary_count}"
+            exit 1
+          fi
+          ls -la
 
       - name: Create Draft GitHub Release
         id: create_release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: Release ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.verify-tag.outputs.tag }}
+          name: Release ${{ needs.verify-tag.outputs.tag }}
           draft: true
           prerelease: false
           generate_release_notes: true
@@ -211,7 +256,13 @@ jobs:
             Verify build provenance using the [GitHub CLI](https://cli.github.com/):
 
             ```bash
-            gh attestation verify curl-amd64 --repo ${{ github.repository }}
+            gh attestation verify curl-amd64 --repo ${{ github.repository }} --signer-workflow ${{ github.repository }}/.github/workflows/attest.yml
+            ```
+
+            Or use the wrapper script:
+
+            ```bash
+            ./scripts/verify.sh curl-amd64
             ```
 
             ### Checksums
@@ -221,5 +272,5 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.verify-tag.outputs.tag }}
           draft: false

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # static-tools
 
-Statically compiled binaries for common Linux tools with verified SLSA Level 3 supply chain provenance.
+Statically compiled binaries for common Linux tools with SLSA v1.2 Build L3 provenance.
+
+See [docs/SLSA.md](docs/SLSA.md) for the claim, how it is achieved, and how to verify it.
 
 ## Overview
 
-This repository provides statically linked binaries that can run on any Linux system without dependencies. All builds are performed in containers with cryptographically signed provenance attestations, enabling verification of the complete build chain.
+This repository provides statically linked binaries that can run on any Linux system without dependencies. Release builds run in digest-pinned containers. Provenance is signed in an isolated reusable workflow so the build job cannot mint attestations.
 
-The provenance provided by this repository is intended to prove the supply chain between upstream
-source code (i.e. the source for the binary being built) and the binary used by an end user. You
-can be assured that the binaries provided by this repo are built in public view using legitimate
-and verified source code. This does not prove the supply chain for upstream source code.
-
-In the future this repository may classify binaries generated from source code which itself provides
-SLSA 3+ provenance. For now that is left up to the user.
+The provenance is intended to prove the supply chain between upstream source (the tarball being built) and the binary an end user downloads. It does not prove the supply chain of that upstream source.
 
 ## Available Tools
 
 | Tool | Version | Description |
 |------|---------|-------------|
-| mtr | 0.95 | Network diagnostic combining ping and traceroute |
+| mtr | 0.95 | Network diagnostic combining ping and traceroute (includes `mtr-packet`) |
 | drill | 1.8.4 | DNS lookup utility (ldns) - lightweight dig alternative |
 | dig | 9.16.50 | DNS lookup utility from BIND - full-featured DNS diagnostics |
 | curl | 8.11.1 | Command line URL transfer tool |
@@ -33,11 +29,11 @@ SLSA 3+ provenance. For now that is left up to the user.
 | fping | 5.4 | Ping multiple hosts in parallel |
 | strace | 6.17 | System-call tracer |
 | ncdu | 1.22 | NCurses disk-usage analyzer |
-| file | 5.46 | File type identification (includes magic.mgc) |
+| file | 5.46 | File type identification (includes `magic.mgc`; use `file -m magic.mgc-<arch>` or `MAGIC=`) |
 | xxd | 1.3.16 | Hex dump utility (tinyxxd) |
 | htop | 3.5.3 | Interactive process viewer |
 
-Each tool lives in `tools/<name>/` with its version pinned in `versions.mk`. Release artifacts are named `<tool>-<arch>` (for example `curl-amd64`).
+Each tool lives in `tools/<name>/` with its version pinned in `versions.mk`. Release artifacts are named `<tool>-<arch>` (for example `curl-amd64`). `file` also ships `magic.mgc-<arch>`; `mtr` also ships `mtr-packet-<arch>`.
 
 ## Supported Architectures
 
@@ -56,26 +52,36 @@ chmod +x curl-amd64
 mv curl-amd64 curl
 ```
 
-### Verify Provenance (Recommended)
-
-Verify the SLSA provenance before using binaries:
+`file` does not search for magic next to the binary:
 
 ```bash
-# Install slsa-verifier
-go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@latest
-
-# Download provenance
-curl -LO https://github.com/colinmcintosh/static-tools/releases/latest/download/multiple.intoto.jsonl
-
-slsa-verifier verify-artifact curl-amd64 \
-  --provenance-path multiple.intoto.jsonl \
-  --source-uri github.com/colinmcintosh/static-tools
+curl -LO https://github.com/colinmcintosh/static-tools/releases/latest/download/file-amd64
+curl -LO https://github.com/colinmcintosh/static-tools/releases/latest/download/magic.mgc-amd64
+chmod +x file-amd64
+./file-amd64 -m magic.mgc-amd64 /path/to/something
+# or: MAGIC=/path/to/magic.mgc-amd64 ./file-amd64 /path/to/something
 ```
 
-Or use the included verification script:
+### Verify Provenance (Recommended)
+
+Verify the SLSA provenance before using binaries. Requires the [GitHub CLI](https://cli.github.com/):
 
 ```bash
-./scripts/verify.sh curl-amd64 multiple.intoto.jsonl
+gh attestation verify curl-amd64 \
+  --repo colinmcintosh/static-tools \
+  --signer-workflow colinmcintosh/static-tools/.github/workflows/attest.yml
+```
+
+Or use the included wrapper (also requires `gh`; it does not bootstrap a verifier):
+
+```bash
+./scripts/verify.sh curl-amd64
+```
+
+Then check checksums:
+
+```bash
+sha256sum -c SHA256SUMS.txt
 ```
 
 ## Building Locally
@@ -125,6 +131,7 @@ make clean    # Remove build artifacts
 ```
 static-tools/
 ├── Makefile                    # Root build entry point (`TOOLS` list)
+├── docs/SLSA.md                # Build L3 claim and verification
 ├── deps/                       # Shared static library prefix
 │   ├── Dockerfile
 │   ├── Makefile
@@ -136,7 +143,8 @@ static-tools/
 │       └── versions.mk
 ├── .github/workflows/
 │   ├── ci.yml
-│   └── release.yml
+│   ├── release.yml
+│   └── attest.yml            # Isolated provenance signing (workflow_call)
 └── scripts/
     └── verify.sh
 ```
@@ -158,7 +166,7 @@ To add a new tool (e.g., `dig`):
 
 3. Create `tools/dig/Dockerfile` following the curl pattern:
    - Use Alpine with musl for static linking, pinned by digest
-   - `COPY --from=deps` the shared static prefix (do not `apk add` C libraries)
+   - `COPY --from=deps` the shared static prefix (do not `apk add` C libraries) unless the tool does not link the prefix
    - Verify source tarballs with SHA256
    - Compile with `-static` flags
    - If the tool needs a new library, add it to `deps/` first
@@ -167,20 +175,18 @@ To add a new tool (e.g., `dig`):
 
 5. Add `dig` to the `TOOLS` list in the root `Makefile`
 
-6. Update the CI/release workflows matrix
+6. Update the CI/release workflow matrices, and bump the expected binary count in `release.yml` / `attest.yml` if you add extra artifacts (like `mtr-packet` or `magic.mgc`)
 
 ## Supply Chain Security
 
-### SLSA Level 3 Compliance
-
-This project achieves [SLSA Level 3](https://slsa.dev/spec/v1.0/levels) through:
+Details are in [docs/SLSA.md](docs/SLSA.md). Summary:
 
 | Requirement | Implementation |
 |-------------|----------------|
-| **Provenance generation** | slsa-github-generator |
+| **Provenance generation** | GitHub Artifact Attestations (`actions/attest`) |
 | **Signed provenance** | Sigstore (keyless signing via Fulcio) |
-| **Isolated builds** | GitHub Actions + container builds |
-| **Unforgeable provenance** | Reusable workflows with isolated signing |
+| **Isolated builds** | GitHub-hosted runners + container builds |
+| **Unforgeable provenance** | Reusable `attest.yml`; build job has no OIDC |
 
 ### Version Pinning
 
@@ -194,10 +200,7 @@ All dependencies are pinned for reproducibility:
 
 ### Verification
 
-Every release includes:
-
-- `SHA256SUMS.txt` - Checksums for all binaries
-- `multiple.intoto.jsonl` - SLSA provenance attestation
+Every release includes `SHA256SUMS.txt`. Provenance is stored as GitHub Artifact Attestations (not a `multiple.intoto.jsonl` release asset). Verify with `gh attestation verify` and `--signer-workflow` as above.
 
 ## License
 

--- a/docs/SLSA.md
+++ b/docs/SLSA.md
@@ -1,0 +1,56 @@
+# SLSA Build L3
+
+This repository claims [SLSA](https://slsa.dev/) v1.2 **Build L3** for release
+binaries published from GitHub Actions.
+
+It does **not** claim Source L3 (there is no gittuf). It is not hermetic or
+bit-for-bit reproducible (Build L4-class).
+
+## How
+
+- Builds run on GitHub-hosted ephemeral runners (`ubuntu-24.04` and
+  `ubuntu-24.04-arm`), inside digest-pinned Alpine containers.
+- Upstream tarballs are fetched over HTTPS and verified with SHA256 pins in
+  each tool's `versions.mk` (shared libraries live in `deps/versions.mk`).
+- The shared static prefix is built once per architecture in the same release
+  run (no cross-run cache). `deps` and `build` have `contents: read` only.
+- The `build` job in [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+  cannot mint OIDC tokens or write attestations.
+- Provenance is signed in the reusable workflow
+  [`.github/workflows/attest.yml`](../.github/workflows/attest.yml) using
+  SHA-pinned `actions/attest` (Sigstore keyless signing). Isolation of signing
+  from the build job is what satisfies Build L3.
+- Releases are published as GitHub Releases. Treat released assets as
+  immutable: verify them, do not re-tag or overwrite.
+
+## Verify
+
+1. Attestation (pin the signer workflow):
+
+   ```bash
+   gh attestation verify curl-amd64 \
+     --repo colinmcintosh/static-tools \
+     --signer-workflow colinmcintosh/static-tools/.github/workflows/attest.yml
+   ```
+
+   Or: `./scripts/verify.sh curl-amd64` (requires the GitHub CLI).
+
+2. Checksums:
+
+   ```bash
+   sha256sum -c SHA256SUMS.txt
+   ```
+
+## Source
+
+Source integrity on `main` is enforced with a GitHub branch ruleset: required
+commit signatures, no force-push, no branch deletion. That is not Source L3
+and is not gittuf.
+
+## Exceptions
+
+- **`dig`**: BIND **9.16.50** is the last autoconf line that still links
+  statically. Newer BIND uses Meson and is not built here. 9.16 is
+  upstream-EOL; this is an explicit exception, not a Meson rewrite.
+- **`file`**: libmagic does not search next to the binary. Use
+  `file -m magic.mgc-<arch>` or set `MAGIC=` to the shipped magic file.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,159 +1,49 @@
 #!/usr/bin/env bash
 #
-# Verify SLSA provenance of static-tools release artifacts
+# Verify GitHub Artifact Attestations for static-tools release artifacts.
+#
+# Requires the GitHub CLI (https://cli.github.com/). This script does not
+# download or bootstrap any verifier binary.
 #
 # Usage:
-#   ./scripts/verify.sh <artifact> <provenance> [source-uri]
+#   ./scripts/verify.sh <artifact> [artifact...]
 #
 # Examples:
-#   ./scripts/verify.sh curl-amd64 multiple.intoto.jsonl
-#   ./scripts/verify.sh curl-arm64 multiple.intoto.jsonl github.com/colinmcintosh/static-tools
+#   ./scripts/verify.sh curl-amd64
+#   ./scripts/verify.sh curl-amd64 curl-arm64
 #
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Default source URI (update this to match your repository)
-DEFAULT_SOURCE_URI="github.com/colinmcintosh/static-tools"
-
-# slsa-verifier version (pinned)
-SLSA_VERIFIER_VERSION="2.6.0"
-SLSA_VERIFIER_SHA256_AMD64="a]dbd36cf8739b0e3f39dfb62731c9c4c22ca1582e70fefc2ad19d43c9e3f4"
-SLSA_VERIFIER_SHA256_ARM64="e3c8a6c7be0c3f9c5d48a5c9b3f8a7d2e4b1c6a9f8e7d5c4b3a2918f7e6d5c4"
+REPO="${VERIFY_REPO:-colinmcintosh/static-tools}"
+SIGNER_WORKFLOW="${VERIFY_SIGNER_WORKFLOW:-colinmcintosh/static-tools/.github/workflows/attest.yml}"
 
 usage() {
-    echo "Usage: $0 <artifact> <provenance> [source-uri]"
+    echo "Usage: $0 <artifact> [artifact...]"
     echo ""
-    echo "Arguments:"
-    echo "  artifact     Path to the binary to verify"
-    echo "  provenance   Path to the SLSA provenance file (.intoto.jsonl)"
-    echo "  source-uri   Source repository URI (default: ${DEFAULT_SOURCE_URI})"
+    echo "Verify SLSA build provenance with:"
+    echo "  gh attestation verify <artifact> --repo ${REPO} --signer-workflow ${SIGNER_WORKFLOW}"
     echo ""
-    echo "Examples:"
-    echo "  $0 curl-amd64 multiple.intoto.jsonl"
-    echo "  $0 ./dist/curl-arm64 ./provenance.intoto.jsonl github.com/user/repo"
+    echo "Requires the GitHub CLI: https://cli.github.com/"
     exit 1
 }
 
-log_info() {
-    echo -e "${GREEN}[INFO]${NC} $1"
-}
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI (gh) is required. Install it from https://cli.github.com/" >&2
+    exit 1
+fi
 
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
+if [[ $# -lt 1 ]]; then
+    usage
+fi
 
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-# Check if slsa-verifier is installed
-check_slsa_verifier() {
-    if command -v slsa-verifier &> /dev/null; then
-        log_info "Found slsa-verifier: $(command -v slsa-verifier)"
-        return 0
-    fi
-    return 1
-}
-
-# Install slsa-verifier if not present
-install_slsa_verifier() {
-    log_info "Installing slsa-verifier v${SLSA_VERIFIER_VERSION}..."
-
-    local arch
-    case "$(uname -m)" in
-        x86_64)  arch="amd64" ;;
-        aarch64) arch="arm64" ;;
-        arm64)   arch="arm64" ;;
-        *)
-            log_error "Unsupported architecture: $(uname -m)"
-            exit 1
-            ;;
-    esac
-
-    local os
-    case "$(uname -s)" in
-        Linux)  os="linux" ;;
-        Darwin) os="darwin" ;;
-        *)
-            log_error "Unsupported OS: $(uname -s)"
-            exit 1
-            ;;
-    esac
-
-    local url="https://github.com/slsa-framework/slsa-verifier/releases/download/v${SLSA_VERIFIER_VERSION}/slsa-verifier-${os}-${arch}"
-    local install_dir="${HOME}/.local/bin"
-    mkdir -p "${install_dir}"
-
-    log_info "Downloading from ${url}..."
-    curl -sSL "${url}" -o "${install_dir}/slsa-verifier"
-    chmod +x "${install_dir}/slsa-verifier"
-
-    # Add to PATH if not already there
-    if [[ ":$PATH:" != *":${install_dir}:"* ]]; then
-        log_warn "Add ${install_dir} to your PATH to use slsa-verifier directly"
-        export PATH="${install_dir}:${PATH}"
-    fi
-
-    log_info "Installed slsa-verifier to ${install_dir}/slsa-verifier"
-}
-
-# Verify artifact with SLSA provenance
-verify_artifact() {
-    local artifact="$1"
-    local provenance="$2"
-    local source_uri="${3:-${DEFAULT_SOURCE_URI}}"
-
-    if [[ ! -f "${artifact}" ]]; then
-        log_error "Artifact not found: ${artifact}"
+for artifact in "$@"; do
+    if [[ ! -e "${artifact}" ]]; then
+        echo "ERROR: Artifact not found: ${artifact}" >&2
         exit 1
     fi
-
-    if [[ ! -f "${provenance}" ]]; then
-        log_error "Provenance file not found: ${provenance}"
-        exit 1
-    fi
-
-    log_info "Verifying artifact: ${artifact}"
-    log_info "Provenance file: ${provenance}"
-    log_info "Source URI: ${source_uri}"
-
-    slsa-verifier verify-artifact "${artifact}" \
-        --provenance-path "${provenance}" \
-        --source-uri "${source_uri}"
-
-    local exit_code=$?
-
-    if [[ ${exit_code} -eq 0 ]]; then
-        log_info "✓ Verification successful! Artifact has valid SLSA provenance."
-    else
-        log_error "✗ Verification failed!"
-        exit ${exit_code}
-    fi
-}
-
-# Main
-main() {
-    if [[ $# -lt 2 ]]; then
-        usage
-    fi
-
-    local artifact="$1"
-    local provenance="$2"
-    local source_uri="${3:-${DEFAULT_SOURCE_URI}}"
-
-    # Ensure slsa-verifier is available
-    if ! check_slsa_verifier; then
-        install_slsa_verifier
-    fi
-
-    # Run verification
-    verify_artifact "${artifact}" "${provenance}" "${source_uri}"
-}
-
-main "$@"
+    echo "Verifying ${artifact} (--signer-workflow ${SIGNER_WORKFLOW})"
+    gh attestation verify "${artifact}" \
+        --repo "${REPO}" \
+        --signer-workflow "${SIGNER_WORKFLOW}"
+done


### PR DESCRIPTION
## Summary
- Move attestation into reusable `attest.yml` so the build job has no OIDC.
- Assemble `SHA256SUMS.txt` once (expect 40 binaries) and document verification in `docs/SLSA.md`.
- Keep the shared deps prefix from `#12`: built once per arch in the same release run (no cache), checked out at the release tag. Attest/release ignore `deps-prefix-*` artifacts.

## Test plan
- [x] Rebased onto current `main` (includes #7–#9, #11, #12)
- [ ] Tag a commit and confirm build jobs have `contents: read` only
- [ ] Attest job signs all `*-amd64` / `*-arm64` subjects including `mtr-packet-*` and `magic.mgc-*`
- [ ] Release `SHA256SUMS.txt` line count matches the binary count
- [ ] `gh attestation verify curl-amd64 --repo colinmcintosh/static-tools --signer-workflow colinmcintosh/static-tools/.github/workflows/attest.yml`
- [ ] `workflow_dispatch` fails if the tag is missing or does not match `github.sha`