### PR TITLE
Skip unchanged CI builds and add a stable required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,52 @@ jobs:
           fi
           echo "✓ All commits are signed"
 
+  changes:
+    name: Detect changed tools
+    runs-on: ubuntu-24.04
+    outputs:
+      tools: ${{ steps.detect.outputs.tools }}
+      any: ${{ steps.detect.outputs.any }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect tools to build
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            BASE="${PR_BASE}"
+          else
+            BASE="${BEFORE}"
+          fi
+          if [ -n "${BASE}" ] && ! [[ "${BASE}" =~ ^0+$ ]] && ! git cat-file -e "${BASE}^{commit}"; then
+            git fetch --no-tags origin "${BASE}"
+          fi
+          TOOLS="$(scripts/ci-changed-tools.sh "${BASE}" "${SHA}")"
+          echo "tools=${TOOLS}" >> "${GITHUB_OUTPUT}"
+          if [ "${TOOLS}" = "[]" ]; then
+            echo "any=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "any=true" >> "${GITHUB_OUTPUT}"
+          fi
+
   build:
     name: Build ${{ matrix.tool }}-${{ matrix.arch }}
-    needs: [verify-signatures]
+    needs: [verify-signatures, changes]
+    if: ${{ needs.changes.outputs.any == 'true' }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        tool: [mtr, dig, drill, curl, wget, iperf3, tcpdump, ncat, openssl, rsync, socat, jq, fping, strace, ncdu, file, xxd, htop]
+        tool: ${{ fromJSON(needs.changes.outputs.tools) }}
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -86,3 +124,25 @@ jobs:
 
       - name: Lint Dockerfiles
         run: make lint
+
+  # Stable required check. Matrix job names expand (Build curl-amd64, …),
+  # so a ruleset cannot require the unexpanded template name.
+  ci:
+    name: CI
+    if: ${{ always() && !cancelled() }}
+    needs: [verify-signatures, changes, build, lint]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check required jobs succeeded
+        if: >-
+          ${{
+            needs.verify-signatures.result != 'success'
+            || needs.changes.result != 'success'
+            || needs.lint.result != 'success'
+            || (needs.changes.outputs.any == 'true' && needs.build.result != 'success')
+            || needs.build.result == 'failure'
+            || needs.build.result == 'cancelled'
+          }}
+        run: |
+          echo '${{ toJSON(needs) }}'
+          exit 1

--- a/scripts/ci-changed-tools.sh
+++ b/scripts/ci-changed-tools.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Print a JSON array of tools whose binaries may have changed between two commits.
+# Rebuild everything when the shared deps prefix changes, or when the base
+# commit is missing (new branch / shallow clone).
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <base-sha> <head-sha>" >&2
+  exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+base=$1
+head=$2
+
+list_all_tools() {
+  local d
+  for d in tools/*/; do
+    [[ -d "$d" ]] || continue
+    basename "$d"
+  done | sort
+}
+
+json_array() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "$@"
+}
+
+all_tools=()
+mapfile -t all_tools < <(list_all_tools)
+
+if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+  echo "No base commit; building all tools" >&2
+  json_array "${all_tools[@]}"
+  exit 0
+fi
+
+if ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+  echo "Base commit ${base} not found; building all tools" >&2
+  json_array "${all_tools[@]}"
+  exit 0
+fi
+
+changed=$(git diff --name-only "${base}" "${head}")
+echo "Changed files:" >&2
+if [[ -z "$changed" ]]; then
+  echo "  (none)" >&2
+  echo '[]'
+  exit 0
+fi
+printf '%s\n' "$changed" | sed 's/^/  /' >&2
+
+selected=()
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  case "$file" in
+    deps|deps/*)
+      echo "Shared deps changed; building all tools" >&2
+      json_array "${all_tools[@]}"
+      exit 0
+      ;;
+    tools/*)
+      tool=${file#tools/}
+      tool=${tool%%/*}
+      if [[ -d "tools/${tool}" ]]; then
+        selected+=("$tool")
+      fi
+      ;;
+  esac
+done <<< "$changed"
+
+if ((${#selected[@]} == 0)); then
+  echo "No tool or deps changes; skipping binary builds" >&2
+  echo '[]'
+  exit 0
+fi
+
+mapfile -t selected < <(printf '%s\n' "${selected[@]}" | sort -u)
+echo "Building tools: ${selected[*]}" >&2
+json_array "${selected[@]}"


### PR DESCRIPTION
## Summary
- Skip binary builds unless `deps/` or a `tools/<name>/` path changed, so docs-only PRs no longer wait on every tool.
- Add a single `CI` job the branch ruleset can require. Matrix job names expand (`Build curl-amd64`, …), so the unexpanded template name never reports.

## Test plan
- [x] This PR should skip all 36 build jobs and still get a green `CI` check
- [x] A change under `tools/curl/` should build only curl (amd64 and arm64)
- [x] A change under `deps/` should build every tool
- [x] Confirm the `default` ruleset requires `Verify commit signatures`, `Lint`, and `CI`