### PR TITLE
Share the static prefix across CI and release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,11 @@ jobs:
 
       - name: Verify deps prefix
         run: |
+          # upload-artifact/download-artifact do not preserve execute bits
+          chmod +x dist/deps/${{ matrix.arch }}/bin/*
           test -f dist/deps/${{ matrix.arch }}/lib/libssl.a
+          test -x dist/deps/${{ matrix.arch }}/bin/pkg-config
+          test -x dist/deps/${{ matrix.arch }}/bin/openssl
 
       - name: Build ${{ matrix.tool }} for ${{ matrix.arch }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -71,9 +75,53 @@ jobs:
             echo "any=true" >> "${GITHUB_OUTPUT}"
           fi
 
+  deps:
+    name: Deps ${{ matrix.arch }}
+    needs: [verify-signatures, changes]
+    if: ${{ needs.changes.outputs.any == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Restore deps prefix cache
+        id: cache-deps
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: dist/deps/${{ matrix.arch }}
+          key: deps-${{ matrix.arch }}-${{ hashFiles('deps/Dockerfile', 'deps/versions.mk', 'deps/Makefile') }}
+
+      - name: Build deps prefix
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          make -C deps build ARCH=${{ matrix.arch }} OUT_DIR="${GITHUB_WORKSPACE}/dist"
+
+      - name: Upload deps prefix
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: deps-prefix-${{ matrix.arch }}
+          path: dist/deps/${{ matrix.arch }}/
+          if-no-files-found: error
+          retention-days: 1
+
   build:
     name: Build ${{ matrix.tool }}-${{ matrix.arch }}
-    needs: [verify-signatures, changes]
+    needs: [verify-signatures, changes, deps]
     if: ${{ needs.changes.outputs.any == 'true' }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -94,6 +142,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Download deps prefix
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: deps-prefix-${{ matrix.arch }}
+          path: dist/deps/${{ matrix.arch }}
+
+      - name: Verify deps prefix
+        run: |
+          test -f dist/deps/${{ matrix.arch }}/lib/libssl.a
+
       - name: Build ${{ matrix.tool }} for ${{ matrix.arch }}
         run: |
           make build-${{ matrix.tool }} ARCH=${{ matrix.arch }}
@@ -103,6 +161,7 @@ jobs:
           make test-${{ matrix.tool }} ARCH=${{ matrix.arch }}
 
       - name: Upload build artifacts
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.tool }}-${{ matrix.arch }}-${{ github.sha }}
@@ -130,7 +189,7 @@ jobs:
   ci:
     name: CI
     if: ${{ always() && !cancelled() }}
-    needs: [verify-signatures, changes, build, lint]
+    needs: [verify-signatures, changes, deps, build, lint]
     runs-on: ubuntu-24.04
     steps:
       - name: Check required jobs succeeded
@@ -139,7 +198,10 @@ jobs:
             needs.verify-signatures.result != 'success'
             || needs.changes.result != 'success'
             || needs.lint.result != 'success'
+            || (needs.changes.outputs.any == 'true' && needs.deps.result != 'success')
             || (needs.changes.outputs.any == 'true' && needs.build.result != 'success')
+            || needs.deps.result == 'failure'
+            || needs.deps.result == 'cancelled'
             || needs.build.result == 'failure'
             || needs.build.result == 'cancelled'
           }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
@@ -57,8 +58,16 @@ jobs:
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
+          FORCE_ALL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:build-all') }}
         run: |
           set -euo pipefail
+          if [ "${FORCE_ALL}" = "true" ]; then
+            echo "PR labeled ci:build-all; building all tools"
+            TOOLS="$(scripts/ci-changed-tools.sh --all)"
+            echo "tools=${TOOLS}" >> "${GITHUB_OUTPUT}"
+            echo "any=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             BASE="${PR_BASE}"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,45 @@ env:
   ALPINE_DIGEST_ARM64: "sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a"
 
 jobs:
+  # Shared static prefix, built once per architecture in this run.
+  # Do not restore a cross-run cache here; release provenance stays hermetic.
+  deps:
+    name: Deps ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build deps prefix
+        run: |
+          make -C deps build ARCH=${{ matrix.arch }} OUT_DIR="${GITHUB_WORKSPACE}/dist"
+
+      - name: Upload deps prefix
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: deps-prefix-${{ matrix.arch }}
+          path: dist/deps/${{ matrix.arch }}/
+          if-no-files-found: error
+          retention-days: 1
+
   # Build job - runs on native runners for each architecture
   build:
     name: Build ${{ matrix.tool }}-${{ matrix.arch }}
+    needs: [deps]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -55,6 +91,16 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Download deps prefix
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: deps-prefix-${{ matrix.arch }}
+          path: dist/deps/${{ matrix.arch }}
+
+      - name: Verify deps prefix
+        run: |
+          test -f dist/deps/${{ matrix.arch }}/lib/libssl.a
 
       - name: Build ${{ matrix.tool }} for ${{ matrix.arch }}
         run: |
@@ -120,7 +166,7 @@ jobs:
         run: |
           mkdir -p release
           # Artifacts are named <tool>-<arch> (and SHA256SUMS-<arch>.txt)
-          find artifacts -type f \( -name "*-amd64" -o -name "*-arm64" -o -name "SHA256SUMS-*.txt" \) -exec cp {} release/ \;
+          find artifacts -type f \( -name "*-amd64" -o -name "*-arm64" -o -name "SHA256SUMS-*.txt" \) ! -path 'artifacts/deps-prefix-*/*' -exec cp {} release/ \;
           cd release
           cat SHA256SUMS-*.txt > SHA256SUMS.txt
           ls -la

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,11 @@ jobs:
 
       - name: Verify deps prefix
         run: |
+          # upload-artifact/download-artifact do not preserve execute bits
+          chmod +x dist/deps/${{ matrix.arch }}/bin/*
           test -f dist/deps/${{ matrix.arch }}/lib/libssl.a
+          test -x dist/deps/${{ matrix.arch }}/bin/pkg-config
+          test -x dist/deps/${{ matrix.arch }}/bin/openssl
 
       - name: Build ${{ matrix.tool }} for ${{ matrix.arch }}
         run: |

--- a/scripts/ci-changed-tools.sh
+++ b/scripts/ci-changed-tools.sh
@@ -2,17 +2,14 @@
 # Print a JSON array of tools whose binaries may have changed between two commits.
 # Rebuild everything when the shared deps prefix changes, or when the base
 # commit is missing (new branch / shallow clone).
+# Use --all to force every tool (CI label ci:build-all).
 set -euo pipefail
 
 usage() {
   echo "Usage: $0 <base-sha> <head-sha>" >&2
+  echo "       $0 --all" >&2
   exit 2
 }
-
-[[ $# -eq 2 ]] || usage
-
-base=$1
-head=$2
 
 list_all_tools() {
   local d
@@ -28,6 +25,18 @@ json_array() {
 
 all_tools=()
 mapfile -t all_tools < <(list_all_tools)
+
+if [[ "${1:-}" == "--all" ]]; then
+  [[ $# -eq 1 ]] || usage
+  echo "Forced full tool matrix" >&2
+  json_array "${all_tools[@]}"
+  exit 0
+fi
+
+[[ $# -eq 2 ]] || usage
+
+base=$1
+head=$2
 
 if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
   echo "No base commit; building all tools" >&2


### PR DESCRIPTION
## Summary
- Build the shared static prefix once per architecture and reuse it in tool jobs, instead of compiling it in every matrix cell.
- Cache the exported prefix on CI (not release) so one-tool PRs skip `make deps` when `deps/` is unchanged.
- Cancel superseded PR runs, and skip tool artifact uploads on pull requests to save Actions storage.

## Test plan
- [x] This workflow-only PR should skip binary builds and still get a green `CI` check
- [ ] A later change under `tools/curl/` should run `Deps amd64`/`Deps arm64`, then only curl, and must not upload tool artifacts
- [ ] A later change under `deps/` should rebuild the prefix (cache miss) and every tool
- [ ] Pushing twice to the same PR should cancel the first CI run
- [ ] A push to `main` that builds tools should still upload tool artifacts
- [ ] Release should build the prefix in-run with no cache restore, and must not publish `deps-prefix-*` as release assets