### PR TITLE
Pin attestation identity and gate releases on reviewed commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,9 @@ jobs:
           SHA: ${{ github.sha }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
-          OWNER: ${{ github.repository_owner }}
+          KEY_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          echo "Importing GitHub web-flow and ${OWNER} signing keys..."
-          curl -fsSL https://github.com/web-flow.gpg | gpg --import
-          curl -fsSL "https://github.com/${OWNER}.gpg" | gpg --import
-
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             RANGE="${PR_BASE}..${PR_HEAD}"
           elif [ "${BEFORE}" = "0000000000000000000000000000000000000000" ]; then
@@ -54,30 +50,7 @@ jobs:
             RANGE="${BEFORE}..${SHA}"
           fi
 
-          echo "Checking commit signatures in ${RANGE}..."
-          failed=0
-          while IFS=$'\t' read -r hash status; do
-            [ -z "${hash}" ] && continue
-            case "${status}" in
-              N)
-                echo "::error::Unsigned commit: ${hash}"
-                failed=1
-                ;;
-              B)
-                echo "::error::Bad signature: ${hash}"
-                failed=1
-                ;;
-              E)
-                echo "::error::Cannot check signature (missing key): ${hash}"
-                failed=1
-                ;;
-            esac
-          done < <(git log --format="%H%x09%G?" "${RANGE}")
-
-          if [ "${failed}" -ne 0 ]; then
-            exit 1
-          fi
-          echo "✓ Commit signatures verified for ${RANGE}"
+          scripts/verify-commit-signatures.sh "${RANGE}"
 
   changes:
     name: Detect changed tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,15 @@ jobs:
       contents: read
     outputs:
       tag: ${{ steps.verify.outputs.tag }}
+      sha: ${{ steps.verify.outputs.sha }}
     steps:
       - name: Checkout refs/tags/<tag>
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          # Full history so the tag commit can be checked against main and its
+          # signature verified.
+          fetch-depth: 0
 
       - name: Verify tag points at the commit being built
         id: verify
@@ -59,7 +63,27 @@ jobs:
             exit 1
           fi
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${TAG_SHA}" >> "${GITHUB_OUTPUT}"
           echo "Verified tag ${TAG} at ${TAG_SHA}"
+
+      - name: Verify tag commit is reachable from main
+        env:
+          TAG: ${{ steps.verify.outputs.tag }}
+          TAG_SHA: ${{ steps.verify.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "+refs/heads/main:refs/remotes/origin/main"
+          if ! git merge-base --is-ancestor "${TAG_SHA}" origin/main; then
+            echo "::error::Tag ${TAG} points at ${TAG_SHA}, which is not reachable from origin/main. Releases must be cut from commits merged to main."
+            exit 1
+          fi
+          echo "✓ ${TAG_SHA} is reachable from origin/main"
+
+      - name: Verify tag commit signature
+        env:
+          TAG_SHA: ${{ steps.verify.outputs.sha }}
+          KEY_OWNER: ${{ github.repository_owner }}
+        run: scripts/verify-commit-signatures.sh "${TAG_SHA}^!"
 
   # Shared static prefix, built once per architecture in this run.
   # Do not restore a cross-run cache here; release provenance stays hermetic.
@@ -256,14 +280,22 @@ jobs:
             Verify build provenance using the [GitHub CLI](https://cli.github.com/):
 
             ```bash
-            gh attestation verify curl-amd64 --repo ${{ github.repository }} --signer-workflow ${{ github.repository }}/.github/workflows/attest.yml
+            gh attestation verify curl-amd64 \
+              --repo ${{ github.repository }} \
+              --cert-identity https://github.com/${{ github.repository }}/.github/workflows/attest.yml@refs/tags/${{ needs.verify-tag.outputs.tag }} \
+              --source-ref refs/tags/${{ needs.verify-tag.outputs.tag }} \
+              --deny-self-hosted-runners
             ```
 
             Or use the wrapper script:
 
             ```bash
-            ./scripts/verify.sh curl-amd64
+            ./scripts/verify.sh ${{ needs.verify-tag.outputs.tag }} curl-amd64
             ```
+
+            `--cert-identity` pins both the signing workflow and the tag it ran
+            from. `--signer-workflow` matches only the workflow path, so on its
+            own it would accept an attestation produced from any ref.
 
             ### Checksums
 

--- a/README.md
+++ b/README.md
@@ -69,14 +69,21 @@ Verify the SLSA provenance before using binaries. Requires the [GitHub CLI](http
 ```bash
 gh attestation verify curl-amd64 \
   --repo colinmcintosh/static-tools \
-  --signer-workflow colinmcintosh/static-tools/.github/workflows/attest.yml
+  --cert-identity https://github.com/colinmcintosh/static-tools/.github/workflows/attest.yml@refs/tags/v2026.09.3 \
+  --source-ref refs/tags/v2026.09.3 \
+  --deny-self-hosted-runners
 ```
 
 Or use the included wrapper (also requires `gh`; it does not bootstrap a verifier):
 
 ```bash
-./scripts/verify.sh curl-amd64
+./scripts/verify.sh v2026.09.3 curl-amd64
 ```
+
+Substitute the tag of the release you downloaded. Pinning the tag matters:
+`--cert-identity` binds both the signing workflow and the ref it ran from,
+while `--signer-workflow` matches only the workflow path and would accept an
+attestation produced from any branch.
 
 Then check checksums:
 

--- a/docs/SLSA.md
+++ b/docs/SLSA.md
@@ -25,15 +25,24 @@ bit-for-bit reproducible (Build L4-class).
 
 ## Verify
 
-1. Attestation (pin the signer workflow):
+1. Attestation (pin the signer workflow *and* the tag it ran from):
 
    ```bash
    gh attestation verify curl-amd64 \
      --repo colinmcintosh/static-tools \
-     --signer-workflow colinmcintosh/static-tools/.github/workflows/attest.yml
+     --cert-identity https://github.com/colinmcintosh/static-tools/.github/workflows/attest.yml@refs/tags/v2026.09.3 \
+     --source-ref refs/tags/v2026.09.3 \
+     --deny-self-hosted-runners
    ```
 
-   Or: `./scripts/verify.sh curl-amd64` (requires the GitHub CLI).
+   Or: `./scripts/verify.sh v2026.09.3 curl-amd64` (requires the GitHub CLI).
+
+   `--signer-workflow` is not sufficient on its own. It matches only
+   `<owner>/<repo>/<path>` and discards the `@<ref>` portion of the certificate
+   identity, so it accepts an attestation minted by `attest.yml` from any ref.
+   `attest.yml` is `workflow_call`, so any workflow in the repository can invoke
+   it. `--cert-identity` pins the ref; `--source-ref` additionally pins the ref
+   the source was built from.
 
 2. Checksums:
 
@@ -46,6 +55,13 @@ bit-for-bit reproducible (Build L4-class).
 Source integrity on `main` is enforced with a GitHub branch ruleset: required
 commit signatures, no force-push, no branch deletion. That is not Source L3
 and is not gittuf.
+
+Tags matching `v*` cannot be moved or deleted once created. Because tag
+*creation* is not restricted, `release.yml` additionally requires that the
+tagged commit is reachable from `origin/main` and carries an acceptable
+signature, so a release cannot be cut from an unreviewed branch. Both workflows
+share one implementation in
+[`scripts/verify-commit-signatures.sh`](../scripts/verify-commit-signatures.sh).
 
 ## Exceptions
 

--- a/scripts/verify-commit-signatures.sh
+++ b/scripts/verify-commit-signatures.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Verify that every commit in a revision range carries an acceptable signature.
+#
+# Trusted keys are fetched from GitHub: the web-flow key, which signs commits
+# created through the GitHub UI and API, and the repository owner's key.
+#
+# Usage:
+#   scripts/verify-commit-signatures.sh <rev-range>
+#
+# Examples:
+#   scripts/verify-commit-signatures.sh origin/main..HEAD
+#   scripts/verify-commit-signatures.sh "${SHA}^!"
+#
+# Environment:
+#   KEY_OWNER   GitHub account whose public keys are trusted
+#               (default: colinmcintosh)
+#
+
+set -euo pipefail
+
+KEY_OWNER="${KEY_OWNER:-colinmcintosh}"
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <rev-range>" >&2
+    exit 2
+fi
+
+range=$1
+
+echo "Importing GitHub web-flow and ${KEY_OWNER} signing keys..."
+curl -fsSL https://github.com/web-flow.gpg | gpg --import
+curl -fsSL "https://github.com/${KEY_OWNER}.gpg" | gpg --import
+
+echo "Checking commit signatures in ${range}..."
+failed=0
+while IFS=$'\t' read -r hash status; do
+    [ -z "${hash}" ] && continue
+    case "${status}" in
+        N)
+            echo "::error::Unsigned commit: ${hash}"
+            failed=1
+            ;;
+        B)
+            echo "::error::Bad signature: ${hash}"
+            failed=1
+            ;;
+        E)
+            echo "::error::Cannot check signature (missing key): ${hash}"
+            failed=1
+            ;;
+    esac
+done < <(git log --format="%H%x09%G?" "${range}")
+
+if [ "${failed}" -ne 0 ]; then
+    exit 1
+fi
+echo "✓ Commit signatures verified for ${range}"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -2,29 +2,39 @@
 #
 # Verify GitHub Artifact Attestations for static-tools release artifacts.
 #
+# The release tag is required. `--signer-workflow` matches only the workflow
+# path and ignores the ref the workflow ran from, so it would accept an
+# attestation minted from any branch. `--cert-identity` pins both.
+#
 # Requires the GitHub CLI (https://cli.github.com/). This script does not
 # download or bootstrap any verifier binary.
 #
 # Usage:
-#   ./scripts/verify.sh <artifact> [artifact...]
+#   ./scripts/verify.sh <tag> <artifact> [artifact...]
 #
 # Examples:
-#   ./scripts/verify.sh curl-amd64
-#   ./scripts/verify.sh curl-amd64 curl-arm64
+#   ./scripts/verify.sh v2026.09.3 curl-amd64
+#   ./scripts/verify.sh v2026.09.3 curl-amd64 curl-arm64
 #
 
 set -euo pipefail
 
 REPO="${VERIFY_REPO:-colinmcintosh/static-tools}"
-SIGNER_WORKFLOW="${VERIFY_SIGNER_WORKFLOW:-colinmcintosh/static-tools/.github/workflows/attest.yml}"
+SIGNER_WORKFLOW_PATH="${VERIFY_SIGNER_WORKFLOW_PATH:-.github/workflows/attest.yml}"
 
 usage() {
-    echo "Usage: $0 <artifact> [artifact...]"
-    echo ""
-    echo "Verify SLSA build provenance with:"
-    echo "  gh attestation verify <artifact> --repo ${REPO} --signer-workflow ${SIGNER_WORKFLOW}"
-    echo ""
-    echo "Requires the GitHub CLI: https://cli.github.com/"
+    cat >&2 <<USAGE
+Usage: $0 <tag> <artifact> [artifact...]
+
+Verify SLSA build provenance, pinned to the release tag so that an attestation
+produced from any other ref is rejected.
+
+Examples:
+  $0 v2026.09.3 curl-amd64
+  $0 v2026.09.3 curl-amd64 curl-arm64
+
+Requires the GitHub CLI: https://cli.github.com/
+USAGE
     exit 1
 }
 
@@ -33,17 +43,35 @@ if ! command -v gh >/dev/null 2>&1; then
     exit 1
 fi
 
-if [[ $# -lt 1 ]]; then
+if [[ $# -lt 2 ]]; then
     usage
 fi
+
+tag=$1
+shift
+
+if [[ "${tag}" != v* ]]; then
+    echo "ERROR: first argument must be a release tag such as v2026.09.3, got '${tag}'" >&2
+    usage
+fi
+
+cert_identity="https://github.com/${REPO}/${SIGNER_WORKFLOW_PATH}@refs/tags/${tag}"
+
+echo "Repository:    ${REPO}"
+echo "Cert identity: ${cert_identity}"
+echo "Source ref:    refs/tags/${tag}"
+echo ""
 
 for artifact in "$@"; do
     if [[ ! -e "${artifact}" ]]; then
         echo "ERROR: Artifact not found: ${artifact}" >&2
         exit 1
     fi
-    echo "Verifying ${artifact} (--signer-workflow ${SIGNER_WORKFLOW})"
+    echo "Verifying ${artifact}..."
     gh attestation verify "${artifact}" \
         --repo "${REPO}" \
-        --signer-workflow "${SIGNER_WORKFLOW}"
+        --cert-identity "${cert_identity}" \
+        --source-ref "refs/tags/${tag}" \
+        --deny-self-hosted-runners
+    echo "✓ ${artifact}"
 done


### PR DESCRIPTION
Closes #13. Closes #14.

Both issues are about the same trust boundary — who can produce an artifact that
passes verification, and what a verifier actually proves — so they are fixed
together. #14's acceptance criteria also call for sharing the signature check
with `ci.yml`, which is the third commit-worthy piece here.

## #13 — Pin the attestation identity

`--signer-workflow` matches only `<owner>/<repo>/<path>` and discards the
`@<ref>` portion of the certificate identity. The real SAN on a release
artifact is:

```
https://github.com/colinmcintosh/static-tools/.github/workflows/attest.yml@refs/tags/v2026.09.3
```

Since `attest.yml` is `workflow_call`, any workflow in the repo can invoke it
from any ref. Branch rules cover only the default branch and CI runs only on
`main` and PRs targeting `main`, so a workflow added on a feature branch is
neither reviewed nor built before it can sign — and the resulting attestation
satisfied the documented command.

`scripts/verify.sh` now takes the release tag and uses `--cert-identity`, which
pins the ref, plus `--source-ref` and `--deny-self-hosted-runners`.

Worth knowing for review: **`--cert-identity` and `--signer-workflow` are
mutually exclusive in `gh`** — passing both is rejected outright — so this is a
replacement rather than an addition.

Measured against the published `curl-amd64` from `v2026.09.3`:

| invocation | exit |
|---|---|
| correct tag | 0 |
| wrong tag (`v2026.09.2`) | 1 |
| tag omitted | 1 |
| first arg not a tag | 1, with a clear message |
| artifact missing | 1 |

Updated to match: `README.md`, `docs/SLSA.md`, and the release-notes body in
`release.yml` (which now interpolates the tag being released).

## #14 — Gate releases on reviewed commits

The `Release tags` ruleset blocks `update` and `deletion` on `v*` but not
`creation`, and `release.yml` verified neither ancestry nor signatures. Pushing
any branch and tagging it produced a fully attested, published release from a
commit that was never reviewed or built.

`verify-tag` now additionally requires that the tagged commit:

1. is reachable from `origin/main`, and
2. carries an acceptable signature.

This needs history, so the checkout gains `fetch-depth: 0`. The job also now
outputs `sha` alongside `tag`, consumed by the two new steps.

Verified in a scratch clone: a commit on a side branch is correctly reported as
not reachable from `origin/main`; a commit on `main` is.

## Shared signature check

The inline block in `ci.yml` moves to `scripts/verify-commit-signatures.sh`,
called by both workflows. `ci.yml` keeps its event-specific range computation
and passes the range in; `release.yml` passes `"${TAG_SHA}^!"`.

**The logic is deliberately unchanged.** It still accepts anything that is not
`N`, `B`, or `E`, which means #19's revoked/expired-key gap now also applies to
the release path. Keeping this commit behaviour-preserving makes the diff
reviewable, and the extraction turns #19 into a single-file change. Confirmed by
driving the real script with a stubbed `git`:

| `%G?` | meaning | exit |
|---|---|---|
| `G` | good | 0 |
| `U` | good, unknown validity | 0 |
| `N` | unsigned | **1** |
| `B` | bad signature | **1** |
| `E` | cannot check | **1** |
| `R` | good sig, **revoked key** | 0 &larr; #19 |
| `X` | **expired** signature | 0 &larr; #19 |
| `Y` | good sig, **expired key** | 0 &larr; #19 |

Also passes against real history: the `v2026.09.3` tag commit, and
`HEAD~5..HEAD` on `main`.

## Deliberately out of scope

- `${{ inputs.tag }}` is still interpolated into the existing `verify-tag`
  step. That is #20. The steps added here use `env:`.
- Requiring signed *tags* (`git verify-tag`) — `make tag-release` creates
  annotated but unsigned tags, so this would need a change to the tagging flow
  and would reject existing tags. The commit signature is what is checked.

## Reviewer notes

- `release.yml` calls `scripts/verify-commit-signatures.sh` from the checked-out
  tag, so the script and the workflow that uses it always ship in the same
  commit.
- The next release cut from `main` will exercise both new gates. The first run
  after merge is the real test of the ancestry step, since it depends on
  `fetch-depth: 0` behaviour in `actions/checkout`.
