### PR TITLE
Upgrade ldns to 1.9.2 for CVE-2026-10846

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The provenance is intended to prove the supply chain between upstream source (th
 | Tool | Version | Description |
 |------|---------|-------------|
 | mtr | 0.95 | Network diagnostic combining ping and traceroute (includes `mtr-packet`) |
-| drill | 1.8.4 | DNS lookup utility (ldns) - lightweight dig alternative |
+| drill | 1.9.2 | DNS lookup utility (ldns) - lightweight dig alternative |
 | dig | 9.16.50 | DNS lookup utility from BIND - full-featured DNS diagnostics |
 | curl | 8.11.1 | Command line URL transfer tool |
 | wget | 1.25.0 | Network file retriever |

--- a/tools/drill/versions.mk
+++ b/tools/drill/versions.mk
@@ -4,6 +4,6 @@
 include ../../deps/versions.mk
 
 # ldns source (provides drill, a dig-like DNS tool)
-LDNS_VERSION := 1.8.4
+LDNS_VERSION := 1.9.2
 LDNS_SOURCE_URL := https://nlnetlabs.nl/downloads/ldns/ldns-$(LDNS_VERSION).tar.gz
-LDNS_SOURCE_SHA256 := 838b907594baaff1cd767e95466a7745998ae64bc74be038dccc62e2de2e4247
+LDNS_SOURCE_SHA256 := b524fa21994b6e834200ceb8c27f1b84bda5982fe35706f058196c079db94d5d


### PR DESCRIPTION
Closes #16.

## What

`ldns` 1.8.4 &rarr; **1.9.2**, which carries the fix for **CVE-2026-10846**
(High, CVSS 7.5).

ldns before 1.9.1, used as a stub resolver over UDP, did not match a response's
source address and port against the query destination. `drill` is exactly that,
so this is an off-path response-spoofing primitive against the shipped binary,
with no build flag that avoids it.

## Confirming the fix is actually in

Rather than trusting the version number:

- The upstream `Changelog` names the CVE directly.
- `net.c` gains `ldns_sockaddr_cmp()`, which compares both address and port on
  the response path &mdash; the check the advisory says was missing.
- The built binary exposes the new `-I <address>` flag ("source address to
  query from") added alongside the fix, so the shipped artifact really is the
  patched code and not a stale layer.

## The risk in this upgrade, and why it did not materialise

`tools/drill/Dockerfile` does not use the normal build target. It links drill
by hand through libtool with an explicit object list:

```
chasetrace.lo dnssec.lo drill.lo drill_util.lo
error.lo root.lo securetrace.lo work.lo
../compat/b64_pton.lo ../compat/b64_ntop.lo
```

A minor-version bump reshuffling those would break the link, so I checked
before building:

| check | result |
|---|---|
| `drill/*.c` file list, 1.8.4 vs 1.9.2 | identical |
| `compat/b64_pton.lo`, `b64_ntop.lo` still produced | yes |
| `--with-drill` in configure | present |
| `--disable-dane`, `--disable-dane-ta-usage` | present |

No Dockerfile change was needed.

## Verification

Built and tested locally on amd64 against the existing shared prefix:

```
✓ drill binary exists
✓ drill binary is statically linked
✓ drill -v works
✓ drill -h works
✓ drill DNS query works
```

- `drill version 1.9.2 (ldns version 1.9.2)`
- `ELF 64-bit LSB executable, x86-64, statically linked, stripped`
- 503 stack-canary sites, consistent with the previous build

arm64 is left to CI, which builds both architectures for changes under
`tools/drill/`.

## Note

This still links OpenSSL 3.3.7 from the shared prefix. #15 replaces that with
3.5 LTS and will rebuild drill again; sequencing ldns first was a deliberate
choice to close a confirmed exploitable bug without waiting on the larger
OpenSSL change.
