### PR TITLE
Fix build break from stale xz apk pin

### DIFF
--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -14,7 +14,7 @@ ARG PREFIX=/opt/st
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz=5.8.4-r0
 
 COPY --from=deps / ${PREFIX}
 

--- a/tools/htop/Dockerfile
+++ b/tools/htop/Dockerfile
@@ -14,7 +14,7 @@ ARG PREFIX=/opt/st
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz=5.8.4-r0
 
 COPY --from=deps / ${PREFIX}
 

--- a/tools/strace/Dockerfile
+++ b/tools/strace/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz=5.8.4-r0
 
 ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LDFLAGS="-static"


### PR DESCRIPTION
Unbreaks `main`. Relates to #22.

## What broke

Alpine moved `xz` from `5.8.3-r0` to `5.8.4-r0` in the v3.21 branch. Alpine's
package index only ever carries the newest revision of a package, so the
exact-version pin no longer resolves:

```
ERROR: unable to select packages:
  xz-5.8.4-r0:
    breaks: world[xz=5.8.3-r0]
```

Three Dockerfiles need `xz` to unpack a `.tar.xz` release tarball and are
therefore broken: **dig, htop, strace**.

## This is already broken on main

Not introduced by any open branch. I reproduced it against `origin/main` with
`docker buildx build --no-cache`.

It is easy to miss locally, because a warm buildx layer cache serves the old
`apk add` layer and the build appears fine — that is exactly how it slipped
past me at first. CI provisions a fresh builder every run, so **CI and any
release cut from `main` today would fail.**

## Audit of the other pins

Checked every pinned apk version in `deps/Dockerfile` and `tools/*/Dockerfile`
against the live v3.21 index while I was here:

| package | pinned | index | |
|---|---|---|---|
| autoconf | 2.72-r0 | 2.72-r0 | ok |
| automake | 1.17-r0 | 1.17-r0 | ok |
| bison | 3.8.2-r1 | 3.8.2-r1 | ok |
| build-base | 0.5-r3 | 0.5-r3 | ok |
| bzip2 | 1.0.8-r6 | 1.0.8-r6 | ok |
| flex | 2.6.4-r6 | 2.6.4-r6 | ok |
| libtool | 2.4.7-r3 | 2.4.7-r3 | ok |
| linux-headers | 6.6-r1 | 6.6-r1 | ok |
| **xz** | **5.8.3-r0** | **5.8.4-r0** | **stale** |

`xz` is the only one that has moved.

## Verification

All three rebuilt with `--no-cache` so a warm layer could not mask the result:

```
dig      builds clean from cold cache
htop     builds clean from cold cache
strace   apk layer OK (no-cache)
```

## Caveat

This is a straight bump to get the build working again. It re-arms the identical
trap for the next `-rN` revision, which will land without warning and present as
the same opaque apk error. #22 is where the strategy question belongs — either
pin the toolchain properly, or stop pinning apk versions and rely on the
digest-pinned base. Worth resolving that soon; this is the failure mode it
predicted, and it fired within hours of the prediction.
