### PR TITLE
Unpin decompressors to fix build break from stale xz pin

### DIFF
--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -13,12 +13,16 @@ ARG PREFIX=/opt/st
 
 # build-base and linux-headers have been stable across Alpine 3.21; they
 # provide gcc/make/strip/musl-dev. Do not apk-add openssl/zlib/nghttp2/perl.
+# bzip2 is left unpinned on purpose: it only decompresses tarballs that are
+# already SHA256-verified, so its version cannot affect the output, while an
+# exact pin breaks the build as soon as Alpine bumps the revision.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     autoconf=2.72-r0 \
     automake=1.17-r0 \
     bison=3.8.2-r1 \
     build-base=0.5-r3 \
-    bzip2=1.0.8-r6 \
+    bzip2 \
     flex=2.6.4-r6 \
     libtool=2.4.7-r3 \
     linux-headers=6.6-r1

--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -11,10 +11,12 @@ ARG TARGETARCH
 ARG PREFIX=/opt/st
 
 # Compiler + xz for the BIND tarball. C libraries come from the SHA256-pinned prefix.
+# The decompressor is unpinned: it only unpacks a SHA256-verified tarball.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz
 
 COPY --from=deps / ${PREFIX}
 

--- a/tools/htop/Dockerfile
+++ b/tools/htop/Dockerfile
@@ -11,10 +11,12 @@ ARG TARGETARCH
 ARG PREFIX=/opt/st
 
 # xz for the official release tarball. ncurses and libcap come from the prefix.
+# The decompressor is unpinned: it only unpacks a SHA256-verified tarball.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz
 
 COPY --from=deps / ${PREFIX}
 

--- a/tools/ncat/Dockerfile
+++ b/tools/ncat/Dockerfile
@@ -11,9 +11,11 @@ ARG TARGETARCH
 ARG PREFIX=/opt/st
 
 # Compiler + bzip2 for the nmap tarball. OpenSSL/zlib/libpcap come from the prefix.
+# The decompressor is unpinned: it only unpacks a SHA256-verified tarball.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     build-base=0.5-r3 \
-    bzip2=1.0.8-r6 \
+    bzip2 \
     linux-headers=6.6-r1
 
 COPY --from=deps / ${PREFIX}

--- a/tools/socat/Dockerfile
+++ b/tools/socat/Dockerfile
@@ -11,9 +11,11 @@ ARG TARGETARCH
 ARG PREFIX=/opt/st
 
 # Compiler + bzip2 for Debian's orig tarball. OpenSSL comes from the SHA256-pinned prefix.
+# The decompressor is unpinned: it only unpacks a SHA256-verified tarball.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     build-base=0.5-r3 \
-    bzip2=1.0.8-r6 \
+    bzip2 \
     linux-headers=6.6-r1
 
 COPY --from=deps / ${PREFIX}

--- a/tools/strace/Dockerfile
+++ b/tools/strace/Dockerfile
@@ -10,10 +10,12 @@ ARG STRACE_SOURCE_SHA256
 ARG TARGETARCH
 
 # xz for the official release tarball. --enable-mpers=no is required for musl static.
+# The decompressor is unpinned: it only unpacks a SHA256-verified tarball.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     build-base=0.5-r3 \
     linux-headers=6.6-r1 \
-    xz=5.8.3-r0
+    xz
 
 ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LDFLAGS="-static"


### PR DESCRIPTION
Unbreaks `main`. Supersedes #39. Relates to #22.

## What broke

Alpine moved `xz` from `5.8.3-r0` to `5.8.4-r0` in the v3.21 branch. Alpine's
index only ever carries the newest revision of a package, so the exact-version
pin stopped resolving:

```
ERROR: unable to select packages:
  xz-5.8.4-r0:
    breaks: world[xz=5.8.3-r0]
```

**dig, htop, and strace** are broken — the three Dockerfiles that unpack a
`.tar.xz`. This is already the state of `main`; I reproduced it there with
`--no-cache`. It hides easily in local development because a warm buildx layer
serves the old `apk add` result, but CI provisions a fresh builder every run,
so CI and any release cut today would fail.

## Why unpin rather than bump

#39 bumped the pin to `5.8.4-r0`. That works, but it re-arms the identical
trap for the next revision, and looking at what the pins actually buy makes a
better answer obvious:

- `xz` and `bzip2` **only decompress tarballs that are already SHA256-verified.**
  Their version cannot influence the artifact, and a corrupted decompress fails
  the hash check regardless. Pinning them bought zero integrity and cost build
  stability.
- The packages that *do* determine the output are **not pinned at all**:

  ```
  build-base-0.5-r3 depends on: binutils file gcc g++ make libc-dev fortify-headers patch
  ```

  All unversioned, so gcc, binutils, and `libc.a` float on every build.

The pinning is inverted: rigid on what cannot matter, absent on what does. This
PR removes the half that only causes breakage.

## What changed

`xz` unpinned in `dig`, `htop`, `strace`; `bzip2` unpinned in `deps`, `ncat`,
`socat`. Each carries a comment explaining why.

Untouched, and audited against the live v3.21 index — all still current:
`autoconf=2.72-r0`, `automake=1.17-r0`, `bison=3.8.2-r1`, `build-base=0.5-r3`,
`flex=2.6.4-r6`, `libtool=2.4.7-r3`, `linux-headers=6.6-r1`. `xz` was the only
stale pin.

`DL3018` is suppressed per-instruction rather than repo-wide, so the rule keeps
applying to the compiler packages.

## Verification

All five affected tools built with `--no-cache`, so a warm layer could not mask
the result:

```
dig      cold-cache build OK
htop     cold-cache build OK
strace   cold-cache build OK
ncat     cold-cache build OK
socat    cold-cache build OK
```

`make lint` passes.

## What this does not fix

The toolchain is still not reproducible — `build-base`'s dependencies float, so
two builds of the same commit at different times can differ. Fixing that means
not fetching packages at build time at all, most likely via a digest-pinned
builder image. #22 tracks it.

Worth noting for that discussion: moving off Alpine would not solve this by
itself. The instability is the live package fetch, not the distro, and
`apt-get` against a mirror behaves the same way. Alpine also has no snapshot
service (Debian has `snapshot.debian.org`), and musl is load-bearing here —
statically linked glibc breaks NSS and would silently kill DNS in curl, wget,
dig, drill, and ncat.
