### PR TITLE
Upgrade OpenSSL to 3.5.8 LTS and curl to 8.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The provenance is intended to prove the supply chain between upstream source (th
 | mtr | 0.95 | Network diagnostic combining ping and traceroute (includes `mtr-packet`) |
 | drill | 1.9.2 | DNS lookup utility (ldns) - lightweight dig alternative |
 | dig | 9.16.50 | DNS lookup utility from BIND - full-featured DNS diagnostics |
-| curl | 8.11.1 | Command line URL transfer tool |
+| curl | 8.22.0 | Command line URL transfer tool |
 | wget | 1.25.0 | Network file retriever |
 | iperf3 | 3.18 | Network bandwidth measurement tool |
 | tcpdump | 4.99.6 | Packet analyzer |
 | ncat | 7.991 | nmap netcat with SSL |
-| openssl | 3.3.7 | Cryptography command-line tool |
+| openssl | 3.5.8 | Cryptography command-line tool |
 | rsync | 3.5.0 | Fast incremental file-copying tool |
 | socat | 1.8.1.3 | Multipurpose relay (SOcket CAT) |
 | jq | 1.8.2 | Command-line JSON processor |

--- a/deps/versions.mk
+++ b/deps/versions.mk
@@ -22,9 +22,11 @@ ZLIB_VERSION := 1.3.2
 ZLIB_URL := https://github.com/madler/zlib/releases/download/v$(ZLIB_VERSION)/zlib-$(ZLIB_VERSION).tar.gz
 ZLIB_SHA256 := bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
 
-OPENSSL_VERSION := 3.3.7
+# 3.5 is the current LTS branch, supported until 2030-04-08. Do not move to a
+# non-LTS branch: 3.4 and 3.6 both go EOL within months.
+OPENSSL_VERSION := 3.5.8
 OPENSSL_URL := https://github.com/openssl/openssl/releases/download/openssl-$(OPENSSL_VERSION)/openssl-$(OPENSSL_VERSION).tar.gz
-OPENSSL_SHA256 := 4900be54e81c4dfe00bb1a10dad33fd8414833573c40d0e9e3274d4ed32e53a2
+OPENSSL_SHA256 := a8f84a39918ec6415ce765d9b429d313ba97b8143169c172e734b9514464f5b2
 
 NGHTTP2_VERSION := 1.69.0
 NGHTTP2_URL := https://github.com/nghttp2/nghttp2/releases/download/v$(NGHTTP2_VERSION)/nghttp2-$(NGHTTP2_VERSION).tar.gz

--- a/tools/curl/versions.mk
+++ b/tools/curl/versions.mk
@@ -4,6 +4,6 @@
 include ../../deps/versions.mk
 
 # curl source (tar.gz so the tool build does not need xz)
-CURL_VERSION := 8.11.1
+CURL_VERSION := 8.22.0
 CURL_SOURCE_URL := https://curl.se/download/curl-$(CURL_VERSION).tar.gz
-CURL_SOURCE_SHA256 := a889ac9dbba3644271bd9d1302b5c22a088893719b72be3487bc3d401e5c4e80
+CURL_SOURCE_SHA256 := d54dd598bf05927a726deb38df31c6a255ba83ff1de57c5d1464dac3ed8f44a1


### PR DESCRIPTION
Closes #15. Closes #17.

OpenSSL is linked into curl, so these belong in one rebuild rather than two.

## OpenSSL 3.3.7 → 3.5.8 LTS

The 3.3 branch reached end of life on 2026-04-09. 3.3.7 is the final 3.3
release and will never receive another fix. From the OpenSSL release strategy
(last modified 2026-05-07):

> Version 3.3 will be supported until 2026-04-09
> Version 3.5 will be supported until 2030-04-08 (LTS)

3.4 and 3.6 expire within months; 3.0 LTS already ended on 2026-09-07. 3.5 is
the only branch with real runway.

Checksum matches the upstream published `.sha256` for
`openssl-3.5.8.tar.gz`.

This is in the shared prefix, so it rebuilds every tool that links OpenSSL:
curl, wget, ncat, tcpdump, dig, drill, socat, iperf3, rsync, and the
standalone `openssl` CLI. Changing `deps/versions.mk` also forces CI to build
the full 18-tool matrix.

## curl 8.11.1 → 8.22.0

8.11.1 is from 2024-12-11. Latest upstream is 8.22.0 (2026-09-02).
`https://curl.se/docs/vuln.json` lists 42 advisories against 8.11.1; 22 apply
to this build (OpenSSL backend, no SSH, no libpsl, no HTTP/3, LDAP/SMB
disabled). The applicable set is dominated by credential and cookie leakage
through incorrect connection reuse.

Every configure flag used in `tools/curl/Dockerfile` is still present in
8.22.0. The Dockerfile URL is unchanged (`https://curl.se/download/curl-${VERSION}.tar.gz`).
Checksum is of that exact tarball (gzip, independently hashed; curl publishes
`.asc` but not a `.sha256` for this release).

## Verification

Rebuilt the shared prefix, then built and tested on amd64:

```
openssl  BUILD_OK TEST_OK
curl     BUILD_OK TEST_OK
wget     BUILD_OK TEST_OK
ncat     BUILD_OK TEST_OK
```

Shipped binaries report:

```
OpenSSL 3.5.8 25 Aug 2026 (Library: OpenSSL 3.5.8 25 Aug 2026)
curl 8.22.0 (x86_64-pc-linux-musl) libcurl/8.22.0 OpenSSL/3.5.8 zlib/1.3.2 zstd/1.5.7 nghttp2/1.69.0
Protocols: file ftp ftps http https ipfs ipns ws wss
```

Both are statically linked. arm64 and the rest of the OpenSSL-linked tools are
left to CI, which will rebuild everything because `deps/versions.mk` changed.

`dig` (BIND 9.16.50) previously built and tested clean against this same
OpenSSL 3.5.8 prefix locally; that was the likeliest API-incompatibility risk
and it did not fire.
