### PR TITLE
Harden CI, signatures, and release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -213,6 +212,12 @@ jobs:
 
       - name: Lint Dockerfiles
         run: make lint
+
+      - name: Test change detection
+        run: scripts/ci-changed-tools-test.sh
+
+      - name: Test commit signature gate
+        run: scripts/verify-commit-signatures-test.sh
 
   # Stable required check. Matrix job names expand (Build curl-amd64, …),
   # so a ruleset cannot require the unexpanded template name.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ on:
 
 permissions: {}
 
+# Tag push and workflow_dispatch of the same tag must not publish over each other.
+# cancel-in-progress is false so a started release is not aborted mid-publish.
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && replace(inputs.tag, 'refs/tags/', '') || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   verify-tag:
     name: Verify release tag
@@ -36,11 +42,13 @@ jobs:
 
       - name: Verify tag points at the commit being built
         id: verify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ inputs.tag }}"
-            TAG="${TAG#refs/tags/}"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TAG="${INPUT_TAG#refs/tags/}"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
@@ -84,6 +92,23 @@ jobs:
           TAG_SHA: ${{ steps.verify.outputs.sha }}
           KEY_OWNER: ${{ github.repository_owner }}
         run: scripts/verify-commit-signatures.sh "${TAG_SHA}^!"
+
+      - name: Refuse to overwrite a published release
+        env:
+          TAG: ${{ steps.verify.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if json=$(gh release view "${TAG}" --json isDraft 2>/dev/null); then
+            is_draft=$(printf '%s' "${json}" | jq -r .isDraft)
+            if [[ "${is_draft}" == "false" ]]; then
+              echo "::error::Release ${TAG} is already published. Re-running would replace assets with different bytes while existing checksums and attestations stay in circulation. Delete the GitHub Release (not the tag) first if a republish is intentional."
+              exit 1
+            fi
+            echo "Draft release ${TAG} exists; this run may update it"
+          else
+            echo "No existing release for ${TAG}"
+          fi
 
   # Shared static prefix, built once per architecture in this run.
   # Do not restore a cross-run cache here; release provenance stays hermetic.
@@ -223,6 +248,20 @@ jobs:
         with:
           ref: ${{ format('refs/tags/{0}', needs.verify-tag.outputs.tag) }}
 
+      - name: Refuse to overwrite a published release
+        env:
+          TAG: ${{ needs.verify-tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if json=$(gh release view "${TAG}" --json isDraft 2>/dev/null); then
+            is_draft=$(printf '%s' "${json}" | jq -r .isDraft)
+            if [[ "${is_draft}" == "false" ]]; then
+              echo "::error::Release ${TAG} is already published. Re-running would replace assets with different bytes while existing checksums and attestations stay in circulation. Delete the GitHub Release (not the tag) first if a republish is intentional."
+              exit 1
+            fi
+          fi
+
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -306,3 +345,46 @@ jobs:
         with:
           tag_name: ${{ needs.verify-tag.outputs.tag }}
           draft: false
+
+  verify-published:
+    name: Verify published assets
+    needs: [verify-tag, release]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ format('refs/tags/{0}', needs.verify-tag.outputs.tag) }}
+
+      - name: Download published release assets
+        env:
+          TAG: ${{ needs.verify-tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p published
+          gh release download "${TAG}" --dir published
+          echo "Published assets:"
+          ls -la published
+
+      - name: Verify published checksums and attestations
+        env:
+          TAG: ${{ needs.verify-tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          VERIFY_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cd published
+          test -f SHA256SUMS.txt
+          sha256sum -c SHA256SUMS.txt
+          mapfile -t bins < <(find . -maxdepth 1 -type f \( -name '*-amd64' -o -name '*-arm64' \) -printf '%f\n' | sort)
+          expected=40
+          if [ "${#bins[@]}" -ne "${expected}" ]; then
+            echo "::error::Expected ${expected} published binaries, found ${#bins[@]}"
+            exit 1
+          fi
+          # SHA256SUMS.txt is not attested; verify binaries only.
+          ../scripts/verify.sh "${TAG}" "${bins[@]}"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The provenance is intended to prove the supply chain between upstream source (th
 | dig | 9.16.50 | DNS lookup utility from BIND - full-featured DNS diagnostics |
 | curl | 8.22.0 | Command line URL transfer tool |
 | wget | 1.25.0 | Network file retriever |
-| iperf3 | 3.18 | Network bandwidth measurement tool |
+| iperf3 | 3.21 | Network bandwidth measurement tool |
 | tcpdump | 4.99.6 | Packet analyzer |
 | ncat | 7.991 | nmap netcat with SSL |
 | openssl | 3.5.8 | Cryptography command-line tool |
@@ -208,6 +208,38 @@ All dependencies are pinned for reproducibility:
 ### Verification
 
 Every release includes `SHA256SUMS.txt`. Provenance is stored as GitHub Artifact Attestations (not a `multiple.intoto.jsonl` release asset). Verify with `gh attestation verify` and `--signer-workflow` as above.
+
+## Known Issues
+
+These are accepted limitations, not accidental omissions.
+
+### `dig` is BIND 9.16.50 (upstream EOL)
+
+BIND **9.16.50** is the last autoconf line that still links statically. Newer BIND uses Meson and is not built here. 9.16 is upstream-EOL.
+
+### `file` does not find `magic.mgc` next to the binary
+
+libmagic does not search next to the binary. Use `file -m magic.mgc-<arch>` or set `MAGIC=` to the shipped magic file.
+
+### `wget` 1.25.0 is the newest release and still has unfixed CVEs
+
+1.25.0 is the latest tarball on ftp.gnu.org. Applicable issues have fixes only as upstream git commits:
+
+- CVE-2026-58470 (5.3) — integer overflow in `parse_content_range()`
+- CVE-2026-58471 (5.9) — heap buffer overflow in `convert_fname()`
+- CVE-2026-58472 (5.9) — heap buffer overflow in `html_quote_string()`
+- CVE-2026-16599 — FTP OPIE/S-KEY unbounded MD5 iteration count (`+opie`)
+
+CVE-2026-58469 (7.5, metalink) does **not** apply: this build is `-metalink`.
+
+### `iperf3` 3.21 server mode is still vulnerable to two DoS CVEs
+
+3.21 is the latest release (2026-04-09). Two server-mode issues have fix commits that postdate 3.21:
+
+- CVE-2026-71217 (7.5) — crafted control-channel JSON causes unbounded stream/thread creation
+- CVE-2026-71218 (5.3) — `JSON_read()` allocates on a peer-controlled length with no upper bound
+
+Both require running as a server (`iperf3 -s`). Client-only use is not exposed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -211,8 +211,6 @@ Every release includes `SHA256SUMS.txt`. Provenance is stored as GitHub Artifact
 
 ## Known Issues
 
-These are accepted limitations, not accidental omissions.
-
 ### `dig` is BIND 9.16.50 (upstream EOL)
 
 BIND **9.16.50** is the last autoconf line that still links statically. Newer BIND uses Meson and is not built here. 9.16 is upstream-EOL.

--- a/docs/SLSA.md
+++ b/docs/SLSA.md
@@ -62,11 +62,8 @@ tagged commit is reachable from `origin/main` and carries an acceptable
 signature, so a release cannot be cut from an unreviewed branch. Both workflows
 share one implementation in
 [`scripts/verify-commit-signatures.sh`](../scripts/verify-commit-signatures.sh).
+Allowed fingerprints are listed in
+[`scripts/allowed-signing-keys.txt`](../scripts/allowed-signing-keys.txt).
 
-## Exceptions
-
-- **`dig`**: BIND **9.16.50** is the last autoconf line that still links
-  statically. Newer BIND uses Meson and is not built here. 9.16 is
-  upstream-EOL; this is an explicit exception, not a Meson rewrite.
-- **`file`**: libmagic does not search next to the binary. Use
-  `file -m magic.mgc-<arch>` or set `MAGIC=` to the shipped magic file.
+Known limitations of individual tools are listed in the
+[README Known Issues](../README.md#known-issues) section.

--- a/scripts/allowed-signing-keys.txt
+++ b/scripts/allowed-signing-keys.txt
@@ -1,0 +1,19 @@
+# Allowed commit-signing key fingerprints (40 hex chars, no spaces).
+# The signature gate imports keys from GitHub so git can verify the
+# cryptographic signature; this file is the trust anchor. Adding a key
+# here is a reviewed change. A key advertised on an account but missing
+# from this list is rejected.
+#
+# GitHub web-flow (current). Signs squash/merge commits created in the UI.
+968479A1AFF927E37D1A566BB5690EEEBB952194
+#
+# GitHub web-flow (historical; expired 2024-01-16). Kept so an old
+# fingerprint is recognized; signatures from an expired key still fail
+# the status-code check (Y).
+5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23
+#
+# Colin McIntosh <colin@colinmcintosh.com> primary [C]
+86777BE82F3B43456B862837B0BD806E5D45F2FF
+#
+# Colin McIntosh signing subkey [SE] — the key git reports as %GF
+A4B4FDDC55108DD6AF1A88E125C4F1CA7EE971E0

--- a/scripts/ci-changed-tools-test.sh
+++ b/scripts/ci-changed-tools-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Path-mapping checks for scripts/ci-changed-tools.sh.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="${ROOT}/scripts/ci-changed-tools.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+git_init_fixture() {
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    git config commit.gpgsign false
+    mkdir -p tools/curl tools/wget deps scripts .github/workflows docs
+    printf 'tool\n' > tools/curl/Dockerfile
+    printf 'tool\n' > tools/wget/Dockerfile
+    printf 'deps\n' > deps/Dockerfile
+    printf 'make\n' > Makefile
+    printf 'hadolint\n' > .hadolint.yaml
+    printf 'script\n' > scripts/foo.sh
+    printf 'ci\n' > .github/workflows/ci.yml
+    printf 'readme\n' > README.md
+    printf 'docs\n' > docs/SLSA.md
+    cp "${SCRIPT}" scripts/ci-changed-tools.sh
+    chmod +x scripts/ci-changed-tools.sh
+    git add -A
+    git commit -qm init
+}
+
+assert_eq() {
+    local got=$1 expected=$2 msg=$3
+    if [[ "${got}" != "${expected}" ]]; then
+        echo "FAIL: ${msg}" >&2
+        echo "  got:      ${got}" >&2
+        echo "  expected: ${expected}" >&2
+        exit 1
+    fi
+    echo "ok: ${msg}"
+}
+
+ALL_TOOLS='["curl", "wget"]'
+
+cd "${TMP}"
+git_init_fixture
+BASE=$(git rev-parse HEAD)
+
+assert_eq "$(scripts/ci-changed-tools.sh --all)" "${ALL_TOOLS}" "--all lists every tool"
+
+# Documentation-only changes must skip builds.
+printf 'x\n' >> README.md
+printf 'x\n' >> docs/SLSA.md
+git add -A && git commit -qm docs
+assert_eq "$(scripts/ci-changed-tools.sh "${BASE}" HEAD)" '[]' "docs-only skips builds"
+
+# Empty range.
+assert_eq "$(scripts/ci-changed-tools.sh HEAD HEAD)" '[]' "empty diff skips builds"
+
+# One tool.
+git reset -q --hard "${BASE}"
+printf 'x\n' >> tools/curl/Dockerfile
+git add -A && git commit -qm curl
+assert_eq "$(scripts/ci-changed-tools.sh "${BASE}" HEAD)" '["curl"]' "tools/curl rebuilds curl only"
+
+# Shared deps rebuild everything.
+git reset -q --hard "${BASE}"
+printf 'x\n' >> deps/Dockerfile
+git add -A && git commit -qm deps
+assert_eq "$(scripts/ci-changed-tools.sh "${BASE}" HEAD)" "${ALL_TOOLS}" "deps rebuilds all tools"
+
+# Infrastructure paths rebuild everything.
+for spec in \
+    "Makefile:Makefile" \
+    ".hadolint.yaml:.hadolint.yaml" \
+    "scripts/foo.sh:scripts" \
+    ".github/workflows/ci.yml:workflows"
+do
+    file=${spec%%:*}
+    label=${spec##*:}
+    git reset -q --hard "${BASE}"
+    printf 'x\n' >> "${file}"
+    git add -A && git commit -qm "${label}"
+    assert_eq "$(scripts/ci-changed-tools.sh "${BASE}" HEAD)" "${ALL_TOOLS}" "${file} rebuilds all tools"
+done
+
+echo "✓ ci-changed-tools path mapping"

--- a/scripts/ci-changed-tools.sh
+++ b/scripts/ci-changed-tools.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Print a JSON array of tools whose binaries may have changed between two commits.
-# Rebuild everything when the shared deps prefix changes, or when the base
-# commit is missing (new branch / shallow clone).
-# Use --all to force every tool (CI label ci:build-all).
+# Rebuild everything when shared deps or build infrastructure changes, or when
+# the base commit is missing (new branch / shallow clone). Documentation-only
+# changes yield []. Use --all to force every tool (CI label ci:build-all).
+#
+# Path mapping is covered by scripts/ci-changed-tools-test.sh.
 set -euo pipefail
 
 usage() {
@@ -68,6 +70,11 @@ while IFS= read -r file; do
       json_array "${all_tools[@]}"
       exit 0
       ;;
+    Makefile|.hadolint.yaml|scripts|scripts/*|.github/workflows|.github/workflows/*)
+      echo "Build infrastructure changed; building all tools" >&2
+      json_array "${all_tools[@]}"
+      exit 0
+      ;;
     tools/*)
       tool=${file#tools/}
       tool=${tool%%/*}
@@ -79,7 +86,7 @@ while IFS= read -r file; do
 done <<< "$changed"
 
 if ((${#selected[@]} == 0)); then
-  echo "No tool or deps changes; skipping binary builds" >&2
+  echo "No tool, deps, or infrastructure changes; skipping binary builds" >&2
   echo '[]'
   exit 0
 fi

--- a/scripts/verify-commit-signatures-test.sh
+++ b/scripts/verify-commit-signatures-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Fail-closed and allowlist checks for scripts/verify-commit-signatures.sh.
+# Uses a stub git/curl/gpg so the test does not need network or real keys.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="${ROOT}/scripts/verify-commit-signatures.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+cat > "${TMP}/allowed.txt" <<'EOF'
+# comment
+968479A1AFF927E37D1A566BB5690EEEBB952194
+A4B4FDDC55108DD6AF1A88E125C4F1CA7EE971E0
+EOF
+
+mkdir -p "${TMP}/bin"
+cat > "${TMP}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "log" ]]; then
+    cat "${GIT_LOG_FIXTURE}"
+    exit 0
+fi
+echo "unexpected git $*" >&2
+exit 2
+EOF
+cat > "${TMP}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "${TMP}/bin/gpg" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${TMP}/bin/git" "${TMP}/bin/curl" "${TMP}/bin/gpg"
+
+export PATH="${TMP}/bin:${PATH}"
+export ALLOWED_SIGNING_KEYS="${TMP}/allowed.txt"
+export GIT_LOG_FIXTURE="${TMP}/log"
+
+run_check() {
+    "${SCRIPT}" HEAD
+}
+
+expect_pass() {
+    local msg=$1
+    if ! run_check; then
+        echo "FAIL: expected pass: ${msg}" >&2
+        exit 1
+    fi
+    echo "ok: pass ${msg}"
+}
+
+expect_fail() {
+    local msg=$1
+    if run_check; then
+        echo "FAIL: expected fail: ${msg}" >&2
+        exit 1
+    fi
+    echo "ok: fail ${msg}"
+}
+
+printf 'abc\tG\tA4B4FDDC55108DD6AF1A88E125C4F1CA7EE971E0\n' > "${TMP}/log"
+expect_pass "G + allowlisted fingerprint"
+
+printf 'abc\tU\t968479A1AFF927E37D1A566BB5690EEEBB952194\n' > "${TMP}/log"
+expect_pass "U + allowlisted fingerprint"
+
+printf 'abc\tG\t25C4F1CA7EE971E0\n' > "${TMP}/log"
+expect_pass "G + 16-char suffix of an allowlisted fingerprint"
+
+printf 'abc\tG\tDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF\n' > "${TMP}/log"
+expect_fail "G + unknown fingerprint"
+
+printf 'abc\tG\tABCD\n' > "${TMP}/log"
+expect_fail "G + fingerprint shorter than 16 hex chars"
+
+for status in N B E X Y R Z; do
+    printf 'abc\t%s\tA4B4FDDC55108DD6AF1A88E125C4F1CA7EE971E0\n' "${status}" > "${TMP}/log"
+    expect_fail "status ${status}"
+done
+
+cat > "${TMP}/bad.txt" <<'EOF'
+not-a-fingerprint
+EOF
+ALLOWED_SIGNING_KEYS="${TMP}/bad.txt"
+export ALLOWED_SIGNING_KEYS
+expect_fail "invalid allowlist file"
+
+echo "✓ verify-commit-signatures fail-closed checks"

--- a/scripts/verify-commit-signatures.sh
+++ b/scripts/verify-commit-signatures.sh
@@ -2,8 +2,14 @@
 #
 # Verify that every commit in a revision range carries an acceptable signature.
 #
-# Trusted keys are fetched from GitHub: the web-flow key, which signs commits
-# created through the GitHub UI and API, and the repository owner's key.
+# Accepts only git %G? statuses G (good, valid) and U (good, unknown validity).
+# Everything else fails, including expired signatures (X), expired keys (Y),
+# revoked keys (R), and any status code a future git release might add.
+#
+# Each accepted signature's fingerprint (%GF) must appear in
+# scripts/allowed-signing-keys.txt. Keys are still imported from GitHub so
+# git can verify the cryptographic signature; the allowlist is the trust
+# anchor, not the live keyring.
 #
 # Usage:
 #   scripts/verify-commit-signatures.sh <rev-range>
@@ -13,13 +19,16 @@
 #   scripts/verify-commit-signatures.sh "${SHA}^!"
 #
 # Environment:
-#   KEY_OWNER   GitHub account whose public keys are trusted
-#               (default: colinmcintosh)
+#   KEY_OWNER              GitHub account whose public keys are imported
+#                          (default: colinmcintosh)
+#   ALLOWED_SIGNING_KEYS   Override path to the fingerprint allowlist
 #
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 KEY_OWNER="${KEY_OWNER:-colinmcintosh}"
+KEYS_FILE="${ALLOWED_SIGNING_KEYS:-${SCRIPT_DIR}/allowed-signing-keys.txt}"
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <rev-range>" >&2
@@ -28,15 +37,68 @@ fi
 
 range=$1
 
+normalize_fp() {
+    printf '%s' "$1" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]'
+}
+
+load_allowed_fingerprints() {
+    if [[ ! -f "${KEYS_FILE}" ]]; then
+        echo "ERROR: allowed signing keys file not found: ${KEYS_FILE}" >&2
+        exit 1
+    fi
+
+    allowed_fps=()
+    local line normalized
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+        line="${line%%#*}"
+        normalized="$(normalize_fp "${line}")"
+        [[ -z "${normalized}" ]] && continue
+        if [[ ! "${normalized}" =~ ^[0-9A-F]{40}$ ]]; then
+            echo "ERROR: invalid fingerprint in ${KEYS_FILE}: ${line}" >&2
+            exit 1
+        fi
+        allowed_fps+=("${normalized}")
+    done < "${KEYS_FILE}"
+
+    if ((${#allowed_fps[@]} == 0)); then
+        echo "ERROR: ${KEYS_FILE} contains no fingerprints" >&2
+        exit 1
+    fi
+}
+
+fingerprint_allowed() {
+    local fp allowed
+    fp="$(normalize_fp "$1")"
+    # git %GF is 40 hex chars; accept a 16+ char suffix so a short key ID
+    # still matches a committed full fingerprint, but reject anything shorter.
+    if ((${#fp} < 16)); then
+        return 1
+    fi
+    for allowed in "${allowed_fps[@]}"; do
+        if [[ "${fp}" == "${allowed}" || "${allowed}" == *"${fp}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+load_allowed_fingerprints
+
 echo "Importing GitHub web-flow and ${KEY_OWNER} signing keys..."
 curl -fsSL https://github.com/web-flow.gpg | gpg --import
 curl -fsSL "https://github.com/${KEY_OWNER}.gpg" | gpg --import
 
 echo "Checking commit signatures in ${range}..."
 failed=0
-while IFS=$'\t' read -r hash status; do
+while IFS=$'\t' read -r hash status fp; do
     [ -z "${hash}" ] && continue
     case "${status}" in
+        G|U)
+            if ! fingerprint_allowed "${fp}"; then
+                echo "::error::Signature fingerprint '${fp}' is not in the allowlist: ${hash}"
+                failed=1
+            fi
+            ;;
         N)
             echo "::error::Unsigned commit: ${hash}"
             failed=1
@@ -49,8 +111,24 @@ while IFS=$'\t' read -r hash status; do
             echo "::error::Cannot check signature (missing key): ${hash}"
             failed=1
             ;;
+        X)
+            echo "::error::Expired signature: ${hash}"
+            failed=1
+            ;;
+        Y)
+            echo "::error::Signature made by expired key: ${hash}"
+            failed=1
+            ;;
+        R)
+            echo "::error::Signature made by revoked key: ${hash}"
+            failed=1
+            ;;
+        *)
+            echo "::error::Unacceptable signature status '${status}' on ${hash}"
+            failed=1
+            ;;
     esac
-done < <(git log --format="%H%x09%G?" "${range}")
+done < <(git log --format="%H%x09%G?%x09%GF" "${range}")
 
 if [ "${failed}" -ne 0 ]; then
     exit 1

--- a/tools/iperf3/versions.mk
+++ b/tools/iperf3/versions.mk
@@ -4,6 +4,6 @@
 include ../../deps/versions.mk
 
 # iperf3 source
-IPERF3_VERSION := 3.18
+IPERF3_VERSION := 3.21
 IPERF3_SOURCE_URL := https://github.com/esnet/iperf/releases/download/$(IPERF3_VERSION)/iperf-$(IPERF3_VERSION).tar.gz
-IPERF3_SOURCE_SHA256 := c0618175514331e766522500e20c94bfb293b4424eb27d7207fb427b88d20bab
+IPERF3_SOURCE_SHA256 := 656e4405ebd620121de7ceca3eaf43a88f79ea1b857d041a6a0b1314801acdd8


### PR DESCRIPTION
Closes #18. Closes #19. Closes #20. Closes #21. Closes #23.

## Summary

- **#18** — `scripts/ci-changed-tools.sh` rebuilds every tool when `Makefile`, `.hadolint.yaml`, `scripts/`, or `.github/workflows/` change. Docs-only edits still skip. Path mapping is covered by `scripts/ci-changed-tools-test.sh`, run from the lint job.
- **#19** — The signature gate is fail-closed: only `G` and `U` pass. `%GF` must match `scripts/allowed-signing-keys.txt`. Keys are still imported from GitHub so git can verify the signature; the allowlist is the trust anchor. Shared by CI and release. Verified against current `main`. Stub tests cover `N/B/E/X/Y/R` and unknown codes.
- **#20** — Dropped vestigial `actions: write` from the CI `deps` job. `release.yml` `verify-tag` reads `github.event_name` and `inputs.tag` through `env:`. Remaining `${{ }}` in `run:` bodies are matrix values from our YAML, not event inputs.
- **#21** — `concurrency` is keyed on the tag with `cancel-in-progress: false`. A published (non-draft) release fails in `verify-tag` and again in `release` so a re-run cannot replace live assets. After publish, `verify-published` downloads the release, checks `SHA256SUMS.txt`, and runs `scripts/verify.sh` on the 40 binaries (`SHA256SUMS.txt` is not attested).
- **#23** — wget 1.25.0 is already the newest ftp.gnu.org tarball. iperf3 is now 3.21 (built and tested locally on amd64). Remaining unfixed CVEs, plus the old SLSA Exceptions (`dig` BIND 9.16 EOL, `file`/`magic.mgc`), are in a Known Issues section at the bottom of the README.

## Test plan

- [x] `scripts/ci-changed-tools-test.sh`
- [x] `scripts/verify-commit-signatures-test.sh`
- [x] `scripts/verify-commit-signatures.sh origin/main` (passes with imported keys)
- [x] `make test-iperf3 ARCH=amd64` (iperf 3.21, statically linked)
- [ ] CI on this PR: full 18×2 matrix (infra paths changed) plus lint/script tests
- [ ] After merge, the next release run should fail if the tag already has a published release, and `verify-published` should pass on a new tag