### PR TITLE
Refresh Alpine, fix make -j races, and ship static PIEs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,13 +194,15 @@ jobs:
         run: |
           make build-${{ matrix.tool }} ARCH=${{ matrix.arch }}
 
-      - name: Verify binary is statically linked
+      - name: Verify binary is a static PIE
+        env:
+          TOOL: ${{ matrix.tool }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          file dist/${{ matrix.tool }}/${{ matrix.arch }}/${{ matrix.tool }} | grep -q "statically linked"
-          echo "✓ ${{ matrix.tool }} is statically linked"
-          if [ "${{ matrix.tool }}" = "mtr" ]; then
-            file dist/mtr/${{ matrix.arch }}/mtr-packet | grep -q "statically linked"
-            echo "✓ mtr-packet is statically linked"
+          set -euo pipefail
+          scripts/assert-static-elf.sh "dist/${TOOL}/${ARCH}/${TOOL}"
+          if [ "${TOOL}" = "mtr" ]; then
+            scripts/assert-static-elf.sh "dist/mtr/${ARCH}/mtr-packet"
           fi
 
       - name: Rename artifacts with architecture suffix

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Details are in [docs/SLSA.md](docs/SLSA.md). Summary:
 
 All dependencies are pinned for reproducibility:
 
-- **Base images**: Alpine pinned by SHA256 digest
+- **Base images**: Alpine pinned by the multi-arch index digest (`deps/versions.mk`)
 - **Source code**: Verified with SHA256 checksums
 - **GitHub Actions**: Pinned by commit SHA
 - **C libraries**: Built from upstream tarballs pinned by URL + SHA256 (`deps/versions.mk`)
@@ -311,6 +311,10 @@ CVE-2026-58469 (7.5, metalink) does **not** apply: this build is `-metalink`.
 - CVE-2026-71218 (5.3) — `JSON_read()` allocates on a peer-controlled length with no upper bound
 
 Both require running as a server (`iperf3 -s`). Client-only use is not exposed.
+
+### Alpine 3.21 reaches EOL on 2026-11-01
+
+The builder is pinned to the 3.21.7 index digest. Move to Alpine 3.24 before EOL; that work is tracked in [#44](https://github.com/colinmcintosh/static-tools/issues/44).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [docs/SLSA.md](docs/SLSA.md) for the claim, how it is achieved, and how to v
 
 ## Overview
 
-This repository provides statically linked binaries that can run on any Linux system without dependencies. Release builds run in digest-pinned containers. Provenance is signed in an isolated reusable workflow so the build job cannot mint attestations.
+This repository provides statically linked PIE binaries that can run on any Linux system without dependencies. They get ASLR (`ET_DYN`, no interpreter). Release builds run in digest-pinned containers. Provenance is signed in an isolated reusable workflow so the build job cannot mint attestations.
 
 The provenance is intended to prove the supply chain between upstream source (the tarball being built) and the binary an end user downloads. It does not prove the supply chain of that upstream source.
 
@@ -248,7 +248,8 @@ To add a new tool (e.g., `dig`):
    - Use Alpine with musl for static linking, pinned by digest
    - `COPY --from=deps` the shared static prefix (do not `apk add` C libraries) unless the tool does not link the prefix
    - Verify source tarballs with SHA256
-   - Compile with `-static` flags
+   - Compile with `-fPIE` / `-static-pie` so the binary is a static PIE
+   - Assert linkage with `readelf` (no `INTERP`, `Type: DYN`), not `file`
    - If the tool needs a new library, add it to `deps/` first
 
 4. Create `tools/dig/Makefile` with build targets

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ No `gh`. This only downloads the latest release assets for your architecture and
 ### Prerequisites
 
 - Docker with BuildKit support
-- GNU Make
+- GNU Make 4.3 or newer (grouped targets for `mtr` and `file`)
 
 ### Build for Your Architecture
 

--- a/deps/Dockerfile
+++ b/deps/Dockerfile
@@ -31,7 +31,7 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
     LDFLAGS="-L${PREFIX}/lib" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 
@@ -81,6 +81,9 @@ RUN wget -q "${ZLIB_URL}" -O zlib.tar.gz && \
     make install && \
     cd /src && rm -rf zlib.tar.gz zlib-${ZLIB_VERSION}
 
+# OpenSSL Configure -static emits a static ET_EXEC CLI; -static-pie on
+# Configure produced a dynamic PIE instead. After install_sw we relink
+# the CLI as a static PIE so the shipped openssl matches the other tools.
 # --- openssl ---
 ARG OPENSSL_VERSION
 ARG OPENSSL_URL
@@ -103,10 +106,17 @@ RUN wget -q "${OPENSSL_URL}" -O openssl.tar.gz && \
         no-tests \
         no-docs \
         no-zlib \
+        enable-pie \
         -static \
         "${OPENSSL_TARGET}" && \
     make -j"$(nproc)" && \
     make install_sw && \
+    cc -static-pie -s -o "${PREFIX}/bin/openssl" \
+        apps/*.o apps/lib/*.o \
+        -Wl,--start-group apps/libapps.a libssl.a libcrypto.a -Wl,--end-group \
+        -ldl -pthread && \
+    readelf -l "${PREFIX}/bin/openssl" | grep -q INTERP && { echo "openssl CLI is not static"; exit 1; } || true && \
+    readelf -h "${PREFIX}/bin/openssl" | grep -q 'Type:[[:space:]]*DYN' && \
     cd /src && rm -rf openssl.tar.gz openssl-${OPENSSL_VERSION}
 
 # --- nghttp2 (library only) ---

--- a/deps/versions.mk
+++ b/deps/versions.mk
@@ -5,8 +5,15 @@
 # are NOT installed via apk; they are fetched by URL and verified with SHA256.
 
 ALPINE_VERSION := 3.21
-ALPINE_DIGEST_AMD64 := sha256:41c81533144786e0beb2b148667355a6c7659aa99a14ed837ff15a98ca9d71f3
-ALPINE_DIGEST_ARM64 := sha256:fac2338de28c1143c0e69b48ba2d9b50481d5f1542b46c4656e5d6912d2d963a
+# Multi-arch index digest of alpine:3.21 (currently 3.21.7). Docker
+# selects the platform from --platform / TARGETARCH, so one pin covers
+# amd64 and arm64 and cannot be paired with the wrong architecture.
+# The per-arch names stay so existing Makefiles keep working.
+# 3.21 EOL is 2026-11-01; migration to 3.24 is tracked in
+# https://github.com/colinmcintosh/static-tools/issues/44
+ALPINE_DIGEST := sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+ALPINE_DIGEST_AMD64 := $(ALPINE_DIGEST)
+ALPINE_DIGEST_ARM64 := $(ALPINE_DIGEST)
 
 # Host tools built into the prefix (perl is required by OpenSSL Configure)
 PERL_VERSION := 5.40.2

--- a/scripts/assert-static-elf.sh
+++ b/scripts/assert-static-elf.sh
@@ -31,5 +31,14 @@ for bin in "$@"; do
         readelf -h "${bin}" >&2
         exit 1
     fi
+    # musl static-pie applies only *RELATIVE relocs. Leftover TLS/symbolic
+    # relocs stay as zeros and crash (BIND isc_tid_v R_*_TPOFF* on amd64).
+    if bad_relocs="$(readelf -Wr "${bin}" | awk '
+        $3 ~ /^R_/ && $3 !~ /RELATIVE$/ { print }
+    ')" && [[ -n "${bad_relocs}" ]]; then
+        echo "ERROR: ${bin} has relocs musl static-pie cannot apply:" >&2
+        echo "${bad_relocs}" >&2
+        exit 1
+    fi
     echo "✓ ${bin} is a static PIE"
 done

--- a/scripts/assert-static-elf.sh
+++ b/scripts/assert-static-elf.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Assert a binary is statically linked and a PIE (ET_DYN, no INTERP).
+#
+# Usage:
+#   scripts/assert-static-elf.sh <binary> [binary...]
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <binary> [binary...]" >&2
+    exit 2
+fi
+
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "ERROR: readelf is required" >&2
+    exit 1
+fi
+
+for bin in "$@"; do
+    if [[ ! -e "${bin}" ]]; then
+        echo "ERROR: ${bin} not found" >&2
+        exit 1
+    fi
+    if readelf -l "${bin}" | grep -q INTERP; then
+        echo "ERROR: ${bin} is not static (INTERP present)" >&2
+        readelf -l "${bin}" >&2
+        exit 1
+    fi
+    if ! readelf -h "${bin}" | grep -q 'Type:[[:space:]]*DYN'; then
+        echo "ERROR: ${bin} is not a PIE (expected ET_DYN)" >&2
+        readelf -h "${bin}" >&2
+        exit 1
+    fi
+    echo "✓ ${bin} is a static PIE"
+done

--- a/tools/curl/Dockerfile
+++ b/tools/curl/Dockerfile
@@ -20,8 +20,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" -O curl.tar.gz && \
@@ -56,11 +56,12 @@ RUN tar xzf curl.tar.gz && \
         --disable-mqtt \
         --disable-manual \
         --disable-docs && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static -all-static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie -all-static" && \
     mkdir -p /out && \
     cp src/curl /out/curl && \
     strip /out/curl && \
-    file /out/curl | grep -q "statically linked" && \
+    ! readelf -l /out/curl | grep -q INTERP && \
+    readelf -h /out/curl | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/curl/Dockerfile
+++ b/tools/curl/Dockerfile
@@ -56,10 +56,11 @@ RUN tar xzf curl.tar.gz && \
         --disable-mqtt \
         --disable-manual \
         --disable-docs && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie -all-static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp src/curl /out/curl && \
     strip /out/curl && \
+    /out/curl --version && \
     ! readelf -l /out/curl | grep -q INTERP && \
     readelf -h /out/curl | grep -q 'Type:[[:space:]]*DYN' && \
     ! readelf -Wr /out/curl | awk '$3 ~ /^R_/ && $3 !~ /RELATIVE$/ { found=1 } END { exit found ? 0 : 1 }' && \

--- a/tools/curl/Dockerfile
+++ b/tools/curl/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
     LDFLAGS="-L${PREFIX}/lib -static-pie" \
-    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    CFLAGS="-Os -fPIE -ftls-model=local-exec -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://curl.se/download/curl-${CURL_VERSION}.tar.gz" -O curl.tar.gz && \
@@ -62,6 +62,7 @@ RUN tar xzf curl.tar.gz && \
     strip /out/curl && \
     ! readelf -l /out/curl | grep -q INTERP && \
     readelf -h /out/curl | grep -q 'Type:[[:space:]]*DYN' && \
+    ! readelf -Wr /out/curl | awk '$3 ~ /^R_/ && $3 !~ /RELATIVE$/ { found=1 } END { exit found ? 0 : 1 }' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/curl/Makefile
+++ b/tools/curl/Makefile
@@ -69,9 +69,7 @@ test: build
 		(echo "ERROR: curl binary not found or not executable" && exit 1)
 	@echo "✓ curl binary exists"
 	@# Check static linking
-	@file $(TOOL_OUT_DIR)/$(ARCH)/curl | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ curl binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/curl
 	@# Run curl --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/curl:/curl:ro \
@@ -99,7 +97,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking curl binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/curl
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/curl
 
 # Clean build artifacts
 .PHONY: clean

--- a/tools/curl/Makefile
+++ b/tools/curl/Makefile
@@ -75,7 +75,7 @@ test: build
 		-v $(TOOL_OUT_DIR)/$(ARCH)/curl:/curl:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /curl --version 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "curl" || \
-		(echo "ERROR: curl --version failed" && exit 1)
+		(echo "ERROR: curl --version failed: $$OUTPUT" && exit 1)
 	@echo "✓ curl --version works"
 	@# Run curl --help in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \

--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -23,8 +23,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://downloads.isc.org/isc/bind9/${BIND9_VERSION}/bind-${BIND9_VERSION}.tar.xz" -O bind.tar.xz && \
@@ -51,7 +51,8 @@ RUN tar xf bind.tar.xz && \
     mkdir -p /out && \
     cp dig /out/dig && \
     strip /out/dig && \
-    file /out/dig | grep -q "statically linked" && \
+    ! readelf -l /out/dig | grep -q INTERP && \
+    readelf -h /out/dig | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/dig/Dockerfile
+++ b/tools/dig/Dockerfile
@@ -24,13 +24,15 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
     LDFLAGS="-L${PREFIX}/lib -static-pie" \
-    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    CFLAGS="-Os -fPIE -ftls-model=local-exec -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://downloads.isc.org/isc/bind9/${BIND9_VERSION}/bind-${BIND9_VERSION}.tar.xz" -O bind.tar.xz && \
     echo "${BIND9_SOURCE_SHA256}  bind.tar.xz" | sha256sum -c -
 
 # BIND 9.16.x is the last autoconf version that allows static compilation.
+# --export-dynamic leaves a TPOFF reloc for isc_tid_v; musl static-pie
+# does not apply it, and amd64 dig then segfaults during OpenSSL init.
 RUN tar xf bind.tar.xz && \
     cd bind-${BIND9_VERSION} && \
     ./configure \
@@ -42,6 +44,7 @@ RUN tar xf bind.tar.xz && \
         --with-libxml2=no \
         --with-libuv="${PREFIX}" \
         --with-nghttp2="${PREFIX}" && \
+    find . -name Makefile -exec sed -i 's/ -Wl,--export-dynamic//g; s/-Wl,--export-dynamic//g' {} + && \
     cd lib/dns/ && make -j"$(nproc)" && \
     cd ../bind9/ && make -j"$(nproc)" && \
     cd ../isc && make -j"$(nproc)" && \
@@ -53,6 +56,7 @@ RUN tar xf bind.tar.xz && \
     strip /out/dig && \
     ! readelf -l /out/dig | grep -q INTERP && \
     readelf -h /out/dig | grep -q 'Type:[[:space:]]*DYN' && \
+    ! readelf -Wr /out/dig | awk '$3 ~ /^R_/ && $3 !~ /RELATIVE$/ { found=1 } END { exit found ? 0 : 1 }' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/dig/Makefile
+++ b/tools/dig/Makefile
@@ -75,7 +75,7 @@ test: build
 		-v $(TOOL_OUT_DIR)/$(ARCH)/dig:/dig:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /dig -v 2>&1) && \
 		echo "$$OUTPUT" | grep -qi "dig" || \
-		(echo "ERROR: dig -v failed" && exit 1)
+		(echo "ERROR: dig -v failed: $$OUTPUT" && exit 1)
 	@echo "✓ dig -v works"
 	@# Run dig -h in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \

--- a/tools/dig/Makefile
+++ b/tools/dig/Makefile
@@ -52,7 +52,7 @@ $(TOOL_OUT_DIR)/$(ARCH)/dig: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libuv.a
 	@echo "Built dig (from BIND $(BIND9_VERSION)) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
-$(DEPS_PREFIX)/lib/libuv.a $(DEPS_PREFIX)/lib/libssl.a:
+$(DEPS_PREFIX)/lib/libuv.a $(DEPS_PREFIX)/lib/libssl.a &:
 	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build for all architectures

--- a/tools/dig/Makefile
+++ b/tools/dig/Makefile
@@ -69,9 +69,7 @@ test: build
 		(echo "ERROR: dig binary not found or not executable" && exit 1)
 	@echo "✓ dig binary exists"
 	@# Check static linking
-	@file $(TOOL_OUT_DIR)/$(ARCH)/dig | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ dig binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/dig
 	@# Run dig -v in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/dig:/dig:ro \
@@ -99,7 +97,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking dig binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/dig
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/dig
 
 # Clean build artifacts
 .PHONY: clean

--- a/tools/drill/Dockerfile
+++ b/tools/drill/Dockerfile
@@ -20,8 +20,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://nlnetlabs.nl/downloads/ldns/ldns-${LDNS_VERSION}.tar.gz" -O ldns.tar.gz && \
@@ -38,10 +38,10 @@ RUN tar xzf ldns.tar.gz && \
         --with-ssl="${PREFIX}" \
         --disable-dane \
         --disable-dane-ta-usage \
-        CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" && \
+        CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" && \
     make -j"$(nproc)" && \
     cd drill && \
-    ../libtool --tag=CC --mode=link gcc -all-static -s -Os \
+    ../libtool --tag=CC --mode=link gcc -static-pie -s -Os \
         -o drill \
         chasetrace.lo dnssec.lo drill.lo drill_util.lo \
         error.lo root.lo securetrace.lo work.lo \
@@ -49,7 +49,8 @@ RUN tar xzf ldns.tar.gz && \
         ../libldns.la -L${PREFIX}/lib -lcrypto -ldl -pthread && \
     mkdir -p /out && \
     cp .libs/drill /out/drill 2>/dev/null || cp drill /out/drill && \
-    file /out/drill | grep -q "statically linked" && \
+    ! readelf -l /out/drill | grep -q INTERP && \
+    readelf -h /out/drill | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/drill/Makefile
+++ b/tools/drill/Makefile
@@ -69,9 +69,7 @@ test: build
 		(echo "ERROR: drill binary not found or not executable" && exit 1)
 	@echo "✓ drill binary exists"
 	@# Check static linking
-	@file $(TOOL_OUT_DIR)/$(ARCH)/drill | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ drill binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/drill
 	@# Run drill -v in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/drill:/drill:ro \
@@ -99,7 +97,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking drill binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/drill
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/drill
 
 # Clean build artifacts
 .PHONY: clean

--- a/tools/file/Dockerfile
+++ b/tools/file/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://astron.com/pub/file/file-${FILE_VERSION}.tar.gz" -O file.tar.gz && \
@@ -42,10 +42,11 @@ RUN tar xzf file.tar.gz && \
         --disable-libseccomp && \
     make -j"$(nproc)" && \
     mkdir -p /out && \
-    gcc -static -o /out/file src/file.o src/seccomp.o src/.libs/libmagic.a -L${PREFIX}/lib -lz && \
+    gcc -static-pie -o /out/file src/file.o src/seccomp.o src/.libs/libmagic.a -L${PREFIX}/lib -lz && \
     cp magic/magic.mgc /out/magic.mgc && \
     strip /out/file && \
-    /usr/bin/file /out/file | grep -q "statically linked" && \
+    ! readelf -l /out/file | grep -q INTERP && \
+    readelf -h /out/file | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/file/Makefile
+++ b/tools/file/Makefile
@@ -47,7 +47,7 @@ test: build
 	@echo "==> Testing file binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/file || (echo "ERROR: file binary not found" && exit 1)
 	@test -f $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc || (echo "ERROR: magic.mgc not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/file | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/file
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/file:/file:ro \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc:/magic.mgc:ro \
@@ -63,7 +63,7 @@ test: build
 	@echo "==> All file tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/file
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/file
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/file/Makefile
+++ b/tools/file/Makefile
@@ -22,7 +22,7 @@ deps:
 
 build: $(TOOL_OUT_DIR)/$(ARCH)/file $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc
 
-$(TOOL_OUT_DIR)/$(ARCH)/file $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libz.a
+$(TOOL_OUT_DIR)/$(ARCH)/file $(TOOL_OUT_DIR)/$(ARCH)/magic.mgc &: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libz.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \

--- a/tools/fping/Dockerfile
+++ b/tools/fping/Dockerfile
@@ -12,8 +12,8 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static"
+ENV CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static-pie"
 
 WORKDIR /src
 RUN wget -q "https://github.com/schweikert/fping/releases/download/v${FPING_VERSION}/fping-${FPING_VERSION}.tar.gz" -O fping.tar.gz && \
@@ -22,11 +22,12 @@ RUN wget -q "https://github.com/schweikert/fping/releases/download/v${FPING_VERS
 RUN tar xzf fping.tar.gz && \
     cd fping-${FPING_VERSION} && \
     ./configure --prefix=/usr && \
-    make -j"$(nproc)" LDFLAGS="-static" && \
+    make -j"$(nproc)" LDFLAGS="-static-pie" && \
     mkdir -p /out && \
     cp src/fping /out/fping && \
     strip /out/fping && \
-    file /out/fping | grep -q "statically linked" && \
+    ! readelf -l /out/fping | grep -q INTERP && \
+    readelf -h /out/fping | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/fping/Makefile
+++ b/tools/fping/Makefile
@@ -38,7 +38,7 @@ build-all:
 test: build
 	@echo "==> Testing fping binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/fping || (echo "ERROR: fping binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/fping | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/fping
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/fping:/fping:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /fping -v 2>&1) && \
@@ -52,7 +52,7 @@ test: build
 	@echo "==> All fping tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/fping
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/fping
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/htop/Dockerfile
+++ b/tools/htop/Dockerfile
@@ -23,8 +23,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://github.com/htop-dev/htop/releases/download/${HTOP_VERSION}/htop-${HTOP_VERSION}.tar.xz" -O htop.tar.xz && \
@@ -34,15 +34,15 @@ RUN tar xf htop.tar.xz && \
     cd htop-${HTOP_VERSION} && \
     ./configure \
         --prefix=/usr \
-        --enable-static \
         --enable-unicode \
         --enable-capabilities \
         --disable-unwind && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp htop /out/htop && \
     strip /out/htop && \
-    file /out/htop | grep -q "statically linked" && \
+    ! readelf -l /out/htop | grep -q INTERP && \
+    readelf -h /out/htop | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/htop/Makefile
+++ b/tools/htop/Makefile
@@ -46,7 +46,7 @@ build-all:
 test: build
 	@echo "==> Testing htop binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/htop || (echo "ERROR: htop binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/htop | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/htop
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/htop:/htop:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /htop --version 2>&1) && \
@@ -60,7 +60,7 @@ test: build
 	@echo "==> All htop tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/htop
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/htop
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/iperf3/Dockerfile
+++ b/tools/iperf3/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
     LDFLAGS="-L${PREFIX}/lib" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://github.com/esnet/iperf/releases/download/${IPERF3_VERSION}/iperf-${IPERF3_VERSION}.tar.gz" -O iperf3.tar.gz && \
@@ -36,12 +36,12 @@ RUN tar xzf iperf3.tar.gz && \
         --enable-static \
         --enable-static-bin \
         --with-openssl="${PREFIX}" && \
-    make -j"$(nproc)" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp src/iperf3 /out/iperf3 && \
     strip /out/iperf3 && \
-    file /out/iperf3 && \
-    file /out/iperf3 | grep -q "statically linked" && \
+    ! readelf -l /out/iperf3 | grep -q INTERP && \
+    readelf -h /out/iperf3 | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/iperf3/Makefile
+++ b/tools/iperf3/Makefile
@@ -69,9 +69,7 @@ test: build
 		(echo "ERROR: iperf3 binary not found or not executable" && exit 1)
 	@echo "✓ iperf3 binary exists"
 	@# Check static linking
-	@file $(TOOL_OUT_DIR)/$(ARCH)/iperf3 | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ iperf3 binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/iperf3
 	@# Run iperf3 --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/iperf3:/iperf3:ro \
@@ -92,7 +90,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking iperf3 binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/iperf3
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/iperf3
 
 # Clean build artifacts
 .PHONY: clean

--- a/tools/jq/Dockerfile
+++ b/tools/jq/Dockerfile
@@ -28,12 +28,13 @@ RUN tar xzf jq.tar.gz && \
         --disable-docs \
         --disable-maintainer-mode \
         --with-oniguruma=builtin && \
-    make -j"$(nproc)" \
-        LDFLAGS="-static-pie -all-static" \
-        jq_LDFLAGS="-static-pie -all-static" && \
+    make -j"$(nproc)" && \
+    ./libtool --tag=CC --mode=link gcc -static-pie -s -o jq \
+        src/main.o libjq.la vendor/oniguruma/src/libonig.la -lm && \
     mkdir -p /out && \
-    cp jq /out/jq && \
+    cp jq /out/jq 2>/dev/null || cp .libs/jq /out/jq && \
     strip /out/jq && \
+    /out/jq --version && \
     ! readelf -l /out/jq | grep -q INTERP && \
     readelf -h /out/jq | grep -q 'Type:[[:space:]]*DYN' && \
     ! readelf -Wr /out/jq | awk '$3 ~ /^R_/ && $3 !~ /RELATIVE$/ { found=1 } END { exit found ? 0 : 1 }' && \

--- a/tools/jq/Dockerfile
+++ b/tools/jq/Dockerfile
@@ -12,8 +12,8 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static"
+ENV CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static-pie"
 
 WORKDIR /src
 RUN wget -q "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-${JQ_VERSION}.tar.gz" -O jq.tar.gz && \
@@ -29,12 +29,13 @@ RUN tar xzf jq.tar.gz && \
         --disable-maintainer-mode \
         --with-oniguruma=builtin && \
     make -j"$(nproc)" \
-        LDFLAGS="-static -all-static" \
-        jq_LDFLAGS="-static -all-static" && \
+        LDFLAGS="-static-pie -all-static" \
+        jq_LDFLAGS="-static-pie -all-static" && \
     mkdir -p /out && \
     cp jq /out/jq && \
     strip /out/jq && \
-    file /out/jq | grep -q "statically linked" && \
+    ! readelf -l /out/jq | grep -q INTERP && \
+    readelf -h /out/jq | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/jq/Dockerfile
+++ b/tools/jq/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-ENV CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+ENV CFLAGS="-Os -fPIE -ftls-model=local-exec -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LDFLAGS="-static-pie"
 
 WORKDIR /src
@@ -36,6 +36,7 @@ RUN tar xzf jq.tar.gz && \
     strip /out/jq && \
     ! readelf -l /out/jq | grep -q INTERP && \
     readelf -h /out/jq | grep -q 'Type:[[:space:]]*DYN' && \
+    ! readelf -Wr /out/jq | awk '$3 ~ /^R_/ && $3 !~ /RELATIVE$/ { found=1 } END { exit found ? 0 : 1 }' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/jq/Makefile
+++ b/tools/jq/Makefile
@@ -38,7 +38,7 @@ build-all:
 test: build
 	@echo "==> Testing jq binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/jq || (echo "ERROR: jq binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/jq | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/jq
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/jq:/jq:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /jq --version 2>&1) && \
@@ -53,7 +53,7 @@ test: build
 	@echo "==> All jq tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/jq
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/jq
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/mtr/Dockerfile
+++ b/tools/mtr/Dockerfile
@@ -22,8 +22,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://github.com/traviscross/mtr/archive/refs/tags/v${MTR_VERSION}.tar.gz" -O mtr.tar.gz && \
@@ -35,11 +35,13 @@ RUN tar xzf mtr.tar.gz && \
     ./configure \
         --without-gtk \
         --without-jansson \
-        CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-        LDFLAGS="-L${PREFIX}/lib -static -s" && \
+        CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+        LDFLAGS="-L${PREFIX}/lib -static-pie -s" && \
     make -j"$(nproc)" && \
-    file mtr | grep -q "statically linked" && \
-    file mtr-packet | grep -q "statically linked" && \
+    ! readelf -l mtr | grep -q INTERP && \
+    readelf -h mtr | grep -q 'Type:[[:space:]]*DYN' && \
+    ! readelf -l mtr-packet | grep -q INTERP && \
+    readelf -h mtr-packet | grep -q 'Type:[[:space:]]*DYN' && \
     mkdir -p /out && \
     cp mtr mtr-packet /out/ && \
     cd /out && sha256sum * > SHA256SUMS

--- a/tools/mtr/Makefile
+++ b/tools/mtr/Makefile
@@ -37,7 +37,7 @@ deps:
 .PHONY: build
 build: $(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet
 
-$(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libncursesw.a
+$(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet &: Dockerfile versions.mk $(DEPS_PREFIX)/lib/libncursesw.a
 	@mkdir -p $(TOOL_OUT_DIR)/$(ARCH)
 	$(BUILDX) build \
 		--platform $(PLATFORM_$(ARCH)) \
@@ -52,7 +52,7 @@ $(TOOL_OUT_DIR)/$(ARCH)/mtr $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet: Dockerfile versi
 	@echo "Built mtr $(MTR_VERSION) for $(ARCH):"
 	@ls -la $(TOOL_OUT_DIR)/$(ARCH)/
 
-$(DEPS_PREFIX)/lib/libncursesw.a $(DEPS_PREFIX)/lib/libssl.a:
+$(DEPS_PREFIX)/lib/libncursesw.a $(DEPS_PREFIX)/lib/libssl.a &:
 	$(MAKE) -C $(CURDIR)/../../deps build ARCH=$(ARCH) OUT_DIR=$(OUT_DIR)
 
 # Build for all architectures

--- a/tools/mtr/Makefile
+++ b/tools/mtr/Makefile
@@ -67,9 +67,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/mtr || \
 		(echo "ERROR: mtr binary not found or not executable" && exit 1)
 	@echo "✓ mtr binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/mtr | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ mtr binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/mtr
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/mtr:/mtr:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /mtr --version 2>&1) && \
@@ -86,9 +84,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet || \
 		(echo "ERROR: mtr-packet binary not found or not executable" && exit 1)
 	@echo "✓ mtr-packet binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet | grep -q "statically linked" || \
-		(echo "ERROR: mtr-packet is not statically linked" && exit 1)
-	@echo "✓ mtr-packet binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/mtr-packet
 	@# mtr-packet is a stdin protocol helper (no --version/--help flags).
 	@# --version equivalent: check-support feature version
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \

--- a/tools/ncat/Dockerfile
+++ b/tools/ncat/Dockerfile
@@ -23,8 +23,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LIBS="-lssl -lcrypto -lz -ldl -lpthread"
 
 WORKDIR /src
@@ -49,7 +49,8 @@ RUN tar xjf nmap.tar.bz2 && \
     mkdir -p /out && \
     cp ncat/ncat /out/ncat && \
     strip /out/ncat && \
-    file /out/ncat | grep -q "statically linked" && \
+    ! readelf -l /out/ncat | grep -q INTERP && \
+    readelf -h /out/ncat | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/ncat/Makefile
+++ b/tools/ncat/Makefile
@@ -56,9 +56,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/ncat || \
 		(echo "ERROR: ncat binary not found or not executable" && exit 1)
 	@echo "✓ ncat binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/ncat | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ ncat binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/ncat
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/ncat:/ncat:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /ncat --version 2>&1) && \
@@ -88,7 +86,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking ncat binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/ncat
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/ncat
 
 .PHONY: clean
 clean:

--- a/tools/ncdu/Dockerfile
+++ b/tools/ncdu/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncursesw" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://dev.yorhel.nl/download/ncdu-${NCDU_VERSION}.tar.gz" -O ncdu.tar.gz && \
@@ -29,11 +29,12 @@ RUN wget -q "https://dev.yorhel.nl/download/ncdu-${NCDU_VERSION}.tar.gz" -O ncdu
 RUN tar xzf ncdu.tar.gz && \
     cd ncdu-${NCDU_VERSION} && \
     ./configure --prefix=/usr && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp ncdu /out/ncdu && \
     strip /out/ncdu && \
-    file /out/ncdu | grep -q "statically linked" && \
+    ! readelf -l /out/ncdu | grep -q INTERP && \
+    readelf -h /out/ncdu | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/ncdu/Makefile
+++ b/tools/ncdu/Makefile
@@ -46,7 +46,7 @@ build-all:
 test: build
 	@echo "==> Testing ncdu binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/ncdu || (echo "ERROR: ncdu binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/ncdu | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/ncdu
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/ncdu:/ncdu:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /ncdu -v 2>&1) && \
@@ -60,7 +60,7 @@ test: build
 	@echo "==> All ncdu tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/ncdu
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/ncdu
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/openssl/Dockerfile
+++ b/tools/openssl/Dockerfile
@@ -17,7 +17,8 @@ COPY --from=deps / ${PREFIX}
 WORKDIR /out
 RUN cp "${PREFIX}/bin/openssl" /out/openssl && \
     strip /out/openssl && \
-    file /out/openssl | grep -q "statically linked" && \
+    ! readelf -l /out/openssl | grep -q INTERP && \
+    readelf -h /out/openssl | grep -q 'Type:[[:space:]]*DYN' && \
     sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/openssl/Makefile
+++ b/tools/openssl/Makefile
@@ -54,9 +54,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/openssl || \
 		(echo "ERROR: openssl binary not found or not executable" && exit 1)
 	@echo "✓ openssl binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/openssl | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ openssl binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/openssl
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/openssl:/openssl:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /openssl version 2>&1) && \
@@ -75,7 +73,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking openssl binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/openssl
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/openssl
 
 .PHONY: clean
 clean:

--- a/tools/rsync/Dockerfile
+++ b/tools/rsync/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://github.com/RsyncProject/rsync/releases/download/v${RSYNC_VERSION}/rsync-${RSYNC_VERSION}.tar.gz" -O rsync.tar.gz && \
@@ -35,11 +35,12 @@ RUN tar xzf rsync.tar.gz && \
         --disable-acl-support \
         --disable-xattr-support \
         --disable-md2man && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp rsync /out/rsync && \
     strip /out/rsync && \
-    file /out/rsync | grep -q "statically linked" && \
+    ! readelf -l /out/rsync | grep -q INTERP && \
+    readelf -h /out/rsync | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/rsync/Makefile
+++ b/tools/rsync/Makefile
@@ -56,9 +56,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/rsync || \
 		(echo "ERROR: rsync binary not found or not executable" && exit 1)
 	@echo "✓ rsync binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/rsync | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ rsync binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/rsync
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/rsync:/rsync:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /rsync --version 2>&1); \
@@ -90,7 +88,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking rsync binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/rsync
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/rsync
 
 .PHONY: clean
 clean:

--- a/tools/socat/Dockerfile
+++ b/tools/socat/Dockerfile
@@ -23,8 +23,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
     LIBS="-lssl -lcrypto -lz -ldl -lpthread"
 
 WORKDIR /src
@@ -38,11 +38,12 @@ RUN tar xjf socat.tar.bz2 && \
         --disable-readline \
         --disable-libwrap \
         --enable-openssl && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp socat /out/socat && \
     strip /out/socat && \
-    file /out/socat | grep -q "statically linked" && \
+    ! readelf -l /out/socat | grep -q INTERP && \
+    readelf -h /out/socat | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/socat/Makefile
+++ b/tools/socat/Makefile
@@ -46,7 +46,7 @@ build-all:
 test: build
 	@echo "==> Testing socat binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/socat || (echo "ERROR: socat binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/socat | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/socat
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/socat:/socat:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /socat -V 2>&1) && \
@@ -60,7 +60,7 @@ test: build
 	@echo "==> All socat tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/socat
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/socat
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/strace/Dockerfile
+++ b/tools/strace/Dockerfile
@@ -17,8 +17,8 @@ RUN apk add --no-cache \
     linux-headers=6.6-r1 \
     xz
 
-ENV CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static"
+ENV CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static-pie"
 
 WORKDIR /src
 RUN wget -q "https://github.com/strace/strace/releases/download/v${STRACE_VERSION}/strace-${STRACE_VERSION}.tar.xz" -O strace.tar.xz && \
@@ -29,11 +29,12 @@ RUN tar xf strace.tar.xz && \
     ./configure \
         --prefix=/usr \
         --enable-mpers=no && \
-    make -j"$(nproc)" LDFLAGS="-static" && \
+    make -j"$(nproc)" LDFLAGS="-static-pie" && \
     mkdir -p /out && \
     cp src/strace /out/strace && \
     strip /out/strace && \
-    file /out/strace | grep -q "statically linked" && \
+    ! readelf -l /out/strace | grep -q INTERP && \
+    readelf -h /out/strace | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/strace/Makefile
+++ b/tools/strace/Makefile
@@ -38,7 +38,7 @@ build-all:
 test: build
 	@echo "==> Testing strace binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/strace || (echo "ERROR: strace binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/strace | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/strace
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/strace:/strace:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /strace -V 2>&1) && \
@@ -51,7 +51,7 @@ test: build
 	@echo "==> All strace tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/strace
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/strace
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)

--- a/tools/tcpdump/Dockerfile
+++ b/tools/tcpdump/Dockerfile
@@ -20,8 +20,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://www.tcpdump.org/release/tcpdump-${TCPDUMP_VERSION}.tar.gz" -O tcpdump.tar.gz && \
@@ -33,11 +33,12 @@ RUN tar xzf tcpdump.tar.gz && \
         --prefix=/usr \
         --disable-shared \
         --with-crypto="${PREFIX}" && \
-    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp tcpdump /out/tcpdump && \
     strip /out/tcpdump && \
-    file /out/tcpdump | grep -q "statically linked" && \
+    ! readelf -l /out/tcpdump | grep -q INTERP && \
+    readelf -h /out/tcpdump | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/tcpdump/Makefile
+++ b/tools/tcpdump/Makefile
@@ -56,9 +56,7 @@ test: build
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/tcpdump || \
 		(echo "ERROR: tcpdump binary not found or not executable" && exit 1)
 	@echo "✓ tcpdump binary exists"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/tcpdump | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ tcpdump binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/tcpdump
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/tcpdump:/tcpdump:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) /tcpdump --version 2>&1) && \
@@ -76,7 +74,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking tcpdump binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/tcpdump
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/tcpdump
 
 .PHONY: clean
 clean:

--- a/tools/wget/Dockerfile
+++ b/tools/wget/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=deps / ${PREFIX}
 ENV PATH="${PREFIX}/bin:${PATH}" \
     PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
     CPPFLAGS="-I${PREFIX}/include" \
-    LDFLAGS="-L${PREFIX}/lib -static" \
-    CFLAGS="-Os -fstack-protector-strong -D_FORTIFY_SOURCE=2"
+    LDFLAGS="-L${PREFIX}/lib -static-pie" \
+    CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2"
 
 WORKDIR /src
 RUN wget -q "https://ftp.gnu.org/gnu/wget/wget-${WGET_VERSION}.tar.gz" -O wget.tar.gz && \
@@ -37,11 +37,12 @@ RUN tar xzf wget.tar.gz && \
         --disable-nls \
         --disable-pcre \
         --disable-iri && \
-    make -j"$(nproc)" SUBDIRS="lib src" LDFLAGS="-L${PREFIX}/lib -static" && \
+    make -j"$(nproc)" SUBDIRS="lib src" LDFLAGS="-L${PREFIX}/lib -static-pie" && \
     mkdir -p /out && \
     cp src/wget /out/wget && \
     strip /out/wget && \
-    file /out/wget | grep -q "statically linked" && \
+    ! readelf -l /out/wget | grep -q INTERP && \
+    readelf -h /out/wget | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/wget/Makefile
+++ b/tools/wget/Makefile
@@ -69,9 +69,7 @@ test: build
 		(echo "ERROR: wget binary not found or not executable" && exit 1)
 	@echo "✓ wget binary exists"
 	@# Check static linking
-	@file $(TOOL_OUT_DIR)/$(ARCH)/wget | grep -q "statically linked" || \
-		(echo "ERROR: Binary is not statically linked" && exit 1)
-	@echo "✓ wget binary is statically linked"
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/wget
 	@# Run wget --version in a container
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/wget:/wget:ro \
@@ -98,7 +96,7 @@ test: build
 .PHONY: verify-static
 verify-static: build
 	@echo "==> Checking wget binary linking for $(ARCH)"
-	@file $(TOOL_OUT_DIR)/$(ARCH)/wget
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/wget
 
 # Clean build artifacts
 .PHONY: clean

--- a/tools/xxd/Dockerfile
+++ b/tools/xxd/Dockerfile
@@ -12,8 +12,8 @@ ARG TARGETARCH
 RUN apk add --no-cache \
     build-base=0.5-r3
 
-ENV CFLAGS="-static -Os -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
-    LDFLAGS="-static"
+ENV CFLAGS="-Os -fPIE -fstack-protector-strong -D_FORTIFY_SOURCE=2" \
+    LDFLAGS="-static-pie"
 
 WORKDIR /src
 RUN wget -q "https://github.com/xyproto/tinyxxd/archive/refs/tags/v${XXD_VERSION}.tar.gz" -O tinyxxd.tar.gz && \
@@ -21,11 +21,12 @@ RUN wget -q "https://github.com/xyproto/tinyxxd/archive/refs/tags/v${XXD_VERSION
 
 RUN tar xzf tinyxxd.tar.gz && \
     cd tinyxxd-${XXD_VERSION} && \
-    make -j"$(nproc)" && \
+    make -j"$(nproc)" CFLAGS="${CFLAGS} ${LDFLAGS}" && \
     mkdir -p /out && \
     cp tinyxxd /out/xxd && \
     strip /out/xxd && \
-    file /out/xxd | grep -q "statically linked" && \
+    ! readelf -l /out/xxd | grep -q INTERP && \
+    readelf -h /out/xxd | grep -q 'Type:[[:space:]]*DYN' && \
     cd /out && sha256sum * > SHA256SUMS
 
 FROM scratch AS export

--- a/tools/xxd/Makefile
+++ b/tools/xxd/Makefile
@@ -38,7 +38,7 @@ build-all:
 test: build
 	@echo "==> Testing xxd binary for $(ARCH)"
 	@test -x $(TOOL_OUT_DIR)/$(ARCH)/xxd || (echo "ERROR: xxd binary not found" && exit 1)
-	@file $(TOOL_OUT_DIR)/$(ARCH)/xxd | grep -q "statically linked" || (echo "ERROR: not statically linked" && exit 1)
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/xxd
 	@OUTPUT=$$($(DOCKER) run --rm --platform $(PLATFORM_$(ARCH)) \
 		-v $(TOOL_OUT_DIR)/$(ARCH)/xxd:/xxd:ro \
 		alpine:$(ALPINE_VERSION)@$(ALPINE_DIGEST_$(ARCH)) \
@@ -48,7 +48,7 @@ test: build
 	@echo "==> All xxd tests passed"
 
 verify-static: build
-	@file $(TOOL_OUT_DIR)/$(ARCH)/xxd
+	@$(CURDIR)/../../scripts/assert-static-elf.sh $(TOOL_OUT_DIR)/$(ARCH)/xxd
 
 clean:
 	rm -rf $(TOOL_OUT_DIR)


### PR DESCRIPTION
Closes #29. Closes #26. Closes #24.

Three commits, one per issue.

## #29 — Alpine 3.21.7 index digest

Per-arch manifests of 3.21.5 were two patch releases behind and could be paired with the wrong `--platform`. One multi-arch index digest (`sha256:48b0309c…`, currently 3.21.7) lets Docker pick the architecture. The 3.24 move before 2026-11-01 EOL is tracked in #44.

## #26 — Grouped targets

`mtr` and `file` used multi-target rules, so `make -j` raced two `buildx` invocations into the same directory. `&:` makes one recipe produce both outputs. Same shape on the `dig` and `mtr` deps prerequisites. README now requires GNU Make 4.3.

## #24 — Static PIE + readelf

Every shipped binary was `ET_EXEC` (no ASLR). All 18 tools plus `mtr-packet` now build as static PIEs (`ET_DYN`, no `INTERP`). OpenSSL's CLI is relinked after `Configure -static`, which otherwise stays EXEC or becomes a dynamic PIE. Dockerfiles, `make test`, and `release.yml` assert that with `readelf` / `scripts/assert-static-elf.sh` instead of grepping `file`.

## Test plan

- [x] `make -n -j8 build-mtr` / `build-file` — one tool `buildx` each (plus deps)
- [x] Local amd64 builds: xxd, jq, fping, strace, curl, wget, file, openssl, iperf3, mtr, drill, ncat, socat, ncdu, tcpdump, rsync, htop, dig — all static PIE
- [x] `make test-xxd` and `make test-openssl`
- [x] CI full 18×2 matrix (infra + tool Dockerfiles changed)